### PR TITLE
feat: Add dummy provider and provider registry (#8)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ members = [
     "crates/fusabi-tui-widgets",
     "scryforge-daemon",
     "scryforge-tui",
+    # Provider crates:
+    "providers/provider-dummy",
     # Future provider crates will be added here:
     # "providers/provider-email-imap",
     # "providers/provider-rss",

--- a/providers/provider-dummy/Cargo.toml
+++ b/providers/provider-dummy/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "provider-dummy"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Dummy provider implementation for testing and development"
+
+[dependencies]
+fusabi-streams-core.workspace = true
+async-trait.workspace = true
+chrono.workspace = true
+
+[dev-dependencies]
+tokio.workspace = true

--- a/providers/provider-dummy/src/lib.rs
+++ b/providers/provider-dummy/src/lib.rs
@@ -1,0 +1,433 @@
+//! # provider-dummy
+//!
+//! A dummy provider implementation for testing and development.
+//!
+//! This provider returns static fixture data and does not connect to any real services.
+//! It implements the `Provider` and `HasFeeds` traits to demonstrate the provider pattern
+//! and to facilitate testing of the daemon and TUI components.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use fusabi_streams_core::prelude::*;
+
+/// A dummy provider that returns static test data.
+pub struct DummyProvider;
+
+impl DummyProvider {
+    /// Create a new dummy provider instance.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Generate static dummy feeds.
+    fn dummy_feeds() -> Vec<Feed> {
+        vec![
+            Feed {
+                id: FeedId("dummy:inbox".to_string()),
+                name: "Dummy Inbox".to_string(),
+                description: Some("A simulated inbox feed with test items".to_string()),
+                icon: Some("📥".to_string()),
+                unread_count: Some(3),
+                total_count: Some(10),
+            },
+            Feed {
+                id: FeedId("dummy:updates".to_string()),
+                name: "Dummy Updates".to_string(),
+                description: Some("Simulated notification feed".to_string()),
+                icon: Some("🔔".to_string()),
+                unread_count: Some(5),
+                total_count: Some(20),
+            },
+            Feed {
+                id: FeedId("dummy:archive".to_string()),
+                name: "Dummy Archive".to_string(),
+                description: Some("Archived test items".to_string()),
+                icon: Some("📦".to_string()),
+                unread_count: Some(0),
+                total_count: Some(100),
+            },
+        ]
+    }
+
+    /// Generate static dummy items for a given feed.
+    fn dummy_items(feed_id: &FeedId) -> Vec<Item> {
+        let stream_id = StreamId::new("dummy", "feed", feed_id.0.as_str());
+
+        match feed_id.0.as_str() {
+            "dummy:inbox" => vec![
+                Item {
+                    id: ItemId::new("dummy", "item-1"),
+                    stream_id: stream_id.clone(),
+                    title: "Welcome to Scryforge".to_string(),
+                    content: ItemContent::Text(
+                        "This is a dummy item from the test provider. \
+                         Scryforge is working correctly!"
+                            .to_string(),
+                    ),
+                    author: Some(Author {
+                        name: "Dummy Provider".to_string(),
+                        email: Some("dummy@scryforge.test".to_string()),
+                        url: None,
+                        avatar_url: None,
+                    }),
+                    published: Some(Utc::now() - chrono::Duration::hours(2)),
+                    updated: None,
+                    url: Some("https://example.com/item-1".to_string()),
+                    thumbnail_url: None,
+                    is_read: false,
+                    is_saved: false,
+                    tags: vec!["test".to_string(), "welcome".to_string()],
+                    metadata: Default::default(),
+                },
+                Item {
+                    id: ItemId::new("dummy", "item-2"),
+                    stream_id: stream_id.clone(),
+                    title: "Test Article with Markdown".to_string(),
+                    content: ItemContent::Markdown(
+                        "# Dummy Article\n\n\
+                         This is a **test article** with _markdown_ formatting.\n\n\
+                         - Bullet point 1\n\
+                         - Bullet point 2\n\n\
+                         [Link to example](https://example.com)"
+                            .to_string(),
+                    ),
+                    author: Some(Author {
+                        name: "Test Author".to_string(),
+                        email: None,
+                        url: Some("https://example.com/author".to_string()),
+                        avatar_url: Some("https://example.com/avatar.jpg".to_string()),
+                    }),
+                    published: Some(Utc::now() - chrono::Duration::hours(5)),
+                    updated: Some(Utc::now() - chrono::Duration::hours(3)),
+                    url: Some("https://example.com/item-2".to_string()),
+                    thumbnail_url: Some("https://example.com/thumb-2.jpg".to_string()),
+                    is_read: false,
+                    is_saved: true,
+                    tags: vec!["test".to_string(), "article".to_string()],
+                    metadata: Default::default(),
+                },
+                Item {
+                    id: ItemId::new("dummy", "item-3"),
+                    stream_id: stream_id.clone(),
+                    title: "Read Item Example".to_string(),
+                    content: ItemContent::Text("This item has been marked as read.".to_string()),
+                    author: None,
+                    published: Some(Utc::now() - chrono::Duration::days(1)),
+                    updated: None,
+                    url: None,
+                    thumbnail_url: None,
+                    is_read: true,
+                    is_saved: false,
+                    tags: vec![],
+                    metadata: Default::default(),
+                },
+            ],
+            "dummy:updates" => vec![
+                Item {
+                    id: ItemId::new("dummy", "update-1"),
+                    stream_id: stream_id.clone(),
+                    title: "System Update Available".to_string(),
+                    content: ItemContent::Text(
+                        "A new version of the system is available.".to_string(),
+                    ),
+                    author: None,
+                    published: Some(Utc::now() - chrono::Duration::minutes(30)),
+                    updated: None,
+                    url: None,
+                    thumbnail_url: None,
+                    is_read: false,
+                    is_saved: false,
+                    tags: vec!["notification".to_string()],
+                    metadata: Default::default(),
+                },
+                Item {
+                    id: ItemId::new("dummy", "update-2"),
+                    stream_id: stream_id.clone(),
+                    title: "New Feature Released".to_string(),
+                    content: ItemContent::Markdown(
+                        "## New Feature\n\nCheck out our latest feature update!".to_string(),
+                    ),
+                    author: Some(Author {
+                        name: "Product Team".to_string(),
+                        email: None,
+                        url: None,
+                        avatar_url: None,
+                    }),
+                    published: Some(Utc::now() - chrono::Duration::hours(1)),
+                    updated: None,
+                    url: Some("https://example.com/updates/feature-1".to_string()),
+                    thumbnail_url: None,
+                    is_read: false,
+                    is_saved: false,
+                    tags: vec!["feature".to_string(), "announcement".to_string()],
+                    metadata: Default::default(),
+                },
+            ],
+            "dummy:archive" => vec![Item {
+                id: ItemId::new("dummy", "archive-1"),
+                stream_id: stream_id.clone(),
+                title: "Archived Item 1".to_string(),
+                content: ItemContent::Text("Old archived content.".to_string()),
+                author: None,
+                published: Some(Utc::now() - chrono::Duration::days(30)),
+                updated: None,
+                url: None,
+                thumbnail_url: None,
+                is_read: true,
+                is_saved: false,
+                tags: vec!["archived".to_string()],
+                metadata: Default::default(),
+            }],
+            _ => vec![],
+        }
+    }
+}
+
+impl Default for DummyProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Provider for DummyProvider {
+    fn id(&self) -> &'static str {
+        "dummy"
+    }
+
+    fn name(&self) -> &'static str {
+        "Dummy Provider"
+    }
+
+    async fn health_check(&self) -> Result<ProviderHealth> {
+        Ok(ProviderHealth {
+            is_healthy: true,
+            message: Some("Dummy provider is always healthy".to_string()),
+            last_sync: Some(Utc::now()),
+            error_count: 0,
+        })
+    }
+
+    async fn sync(&self) -> Result<SyncResult> {
+        // Simulate a successful sync
+        Ok(SyncResult {
+            success: true,
+            items_added: 0,
+            items_updated: 0,
+            items_removed: 0,
+            errors: vec![],
+            duration_ms: 10,
+        })
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            has_feeds: true,
+            has_collections: false,
+            has_saved_items: false,
+            has_communities: false,
+        }
+    }
+
+    async fn available_actions(&self, _item: &Item) -> Result<Vec<Action>> {
+        Ok(vec![
+            Action {
+                id: "open".to_string(),
+                name: "Open".to_string(),
+                description: "Open item".to_string(),
+                kind: ActionKind::Open,
+                keyboard_shortcut: Some("o".to_string()),
+            },
+            Action {
+                id: "preview".to_string(),
+                name: "Preview".to_string(),
+                description: "Show preview".to_string(),
+                kind: ActionKind::Preview,
+                keyboard_shortcut: Some("p".to_string()),
+            },
+            Action {
+                id: "mark_read".to_string(),
+                name: "Mark as Read".to_string(),
+                description: "Mark item as read".to_string(),
+                kind: ActionKind::MarkRead,
+                keyboard_shortcut: Some("r".to_string()),
+            },
+        ])
+    }
+
+    async fn execute_action(&self, _item: &Item, action: &Action) -> Result<ActionResult> {
+        Ok(ActionResult {
+            success: true,
+            message: Some(format!("Executed action: {}", action.name)),
+            data: None,
+        })
+    }
+}
+
+#[async_trait]
+impl HasFeeds for DummyProvider {
+    async fn list_feeds(&self) -> Result<Vec<Feed>> {
+        Ok(Self::dummy_feeds())
+    }
+
+    async fn get_feed_items(&self, feed_id: &FeedId, options: FeedOptions) -> Result<Vec<Item>> {
+        let mut items = Self::dummy_items(feed_id);
+
+        // Apply filtering based on options
+        if !options.include_read {
+            items.retain(|item| !item.is_read);
+        }
+
+        // Apply since filter
+        if let Some(since) = options.since {
+            items.retain(|item| item.published.is_some_and(|pub_date| pub_date > since));
+        }
+
+        // Apply offset and limit
+        let offset = options.offset.unwrap_or(0) as usize;
+        let limit = options.limit.map(|l| l as usize);
+
+        let items = items.into_iter().skip(offset);
+        let items = if let Some(limit) = limit {
+            items.take(limit).collect()
+        } else {
+            items.collect()
+        };
+
+        Ok(items)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_dummy_provider_basics() {
+        let provider = DummyProvider::new();
+
+        assert_eq!(provider.id(), "dummy");
+        assert_eq!(provider.name(), "Dummy Provider");
+
+        let caps = provider.capabilities();
+        assert!(caps.has_feeds);
+        assert!(!caps.has_collections);
+    }
+
+    #[tokio::test]
+    async fn test_health_check() {
+        let provider = DummyProvider::new();
+        let health = provider.health_check().await.unwrap();
+
+        assert!(health.is_healthy);
+        assert_eq!(health.error_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_list_feeds() {
+        let provider = DummyProvider::new();
+        let feeds = provider.list_feeds().await.unwrap();
+
+        assert_eq!(feeds.len(), 3);
+        assert_eq!(feeds[0].id.0, "dummy:inbox");
+        assert_eq!(feeds[1].id.0, "dummy:updates");
+        assert_eq!(feeds[2].id.0, "dummy:archive");
+    }
+
+    #[tokio::test]
+    async fn test_get_feed_items() {
+        let provider = DummyProvider::new();
+        let feed_id = FeedId("dummy:inbox".to_string());
+        let options = FeedOptions {
+            include_read: true, // Include all items
+            ..Default::default()
+        };
+
+        let items = provider.get_feed_items(&feed_id, options).await.unwrap();
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0].title, "Welcome to Scryforge");
+    }
+
+    #[tokio::test]
+    async fn test_get_feed_items_exclude_read() {
+        let provider = DummyProvider::new();
+        let feed_id = FeedId("dummy:inbox".to_string());
+        let options = FeedOptions {
+            include_read: false,
+            ..Default::default()
+        };
+
+        let items = provider.get_feed_items(&feed_id, options).await.unwrap();
+        assert_eq!(items.len(), 2); // One item is marked as read
+        assert!(!items.iter().any(|item| item.is_read));
+    }
+
+    #[tokio::test]
+    async fn test_get_feed_items_with_limit() {
+        let provider = DummyProvider::new();
+        let feed_id = FeedId("dummy:inbox".to_string());
+        let options = FeedOptions {
+            limit: Some(2),
+            ..Default::default()
+        };
+
+        let items = provider.get_feed_items(&feed_id, options).await.unwrap();
+        assert_eq!(items.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_available_actions() {
+        let provider = DummyProvider::new();
+        let item = Item {
+            id: ItemId::new("dummy", "test"),
+            stream_id: StreamId::new("dummy", "feed", "test"),
+            title: "Test".to_string(),
+            content: ItemContent::Text("Test".to_string()),
+            author: None,
+            published: None,
+            updated: None,
+            url: None,
+            thumbnail_url: None,
+            is_read: false,
+            is_saved: false,
+            tags: vec![],
+            metadata: Default::default(),
+        };
+
+        let actions = provider.available_actions(&item).await.unwrap();
+        assert_eq!(actions.len(), 3);
+        assert_eq!(actions[0].kind, ActionKind::Open);
+        assert_eq!(actions[1].kind, ActionKind::Preview);
+        assert_eq!(actions[2].kind, ActionKind::MarkRead);
+    }
+
+    #[tokio::test]
+    async fn test_execute_action() {
+        let provider = DummyProvider::new();
+        let item = Item {
+            id: ItemId::new("dummy", "test"),
+            stream_id: StreamId::new("dummy", "feed", "test"),
+            title: "Test".to_string(),
+            content: ItemContent::Text("Test".to_string()),
+            author: None,
+            published: None,
+            updated: None,
+            url: None,
+            thumbnail_url: None,
+            is_read: false,
+            is_saved: false,
+            tags: vec![],
+            metadata: Default::default(),
+        };
+        let action = Action {
+            id: "open".to_string(),
+            name: "Open".to_string(),
+            description: "Open item".to_string(),
+            kind: ActionKind::Open,
+            keyboard_shortcut: Some("o".to_string()),
+        };
+
+        let result = provider.execute_action(&item, &action).await.unwrap();
+        assert!(result.success);
+    }
+}

--- a/scryforge-daemon/Cargo.toml
+++ b/scryforge-daemon/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 fusabi-streams-core.workspace = true
+provider-dummy = { path = "../providers/provider-dummy" }
 tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -20,6 +21,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 anyhow.workspace = true
 chrono.workspace = true
+async-trait.workspace = true
 jsonrpsee = { version = "0.24", features = ["server", "macros"] }
 
 [dev-dependencies]

--- a/scryforge-daemon/src/lib.rs
+++ b/scryforge-daemon/src/lib.rs
@@ -1,0 +1,5 @@
+//! Scryforge daemon library
+//!
+//! This module exports the internal components of the daemon for testing purposes.
+
+pub mod registry;

--- a/scryforge-daemon/src/registry.rs
+++ b/scryforge-daemon/src/registry.rs
@@ -1,0 +1,265 @@
+//! # Provider Registry
+//!
+//! Manages the collection of loaded providers and provides lookup functionality.
+//!
+//! The registry stores providers by their ID and allows retrieval by ID or listing
+//! all available providers. Providers are stored as trait objects to enable runtime
+//! polymorphism.
+
+use fusabi_streams_core::prelude::*;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Registry for managing loaded providers.
+///
+/// The registry maintains a collection of providers that have been loaded
+/// and initialized. Each provider is identified by its unique ID.
+///
+/// # Example
+///
+/// ```no_run
+/// use scryforge_daemon::registry::ProviderRegistry;
+/// use provider_dummy::DummyProvider;
+///
+/// let mut registry = ProviderRegistry::new();
+/// registry.register(DummyProvider::new());
+///
+/// let provider = registry.get("dummy").unwrap();
+/// println!("Loaded provider: {}", provider.name());
+/// ```
+pub struct ProviderRegistry {
+    providers: HashMap<String, Arc<dyn Provider>>,
+}
+
+impl ProviderRegistry {
+    /// Create a new empty provider registry.
+    pub fn new() -> Self {
+        Self {
+            providers: HashMap::new(),
+        }
+    }
+
+    /// Register a provider with the registry.
+    ///
+    /// The provider's ID will be used as the key. If a provider with the same ID
+    /// already exists, it will be replaced.
+    ///
+    /// # Arguments
+    ///
+    /// * `provider` - The provider instance to register
+    pub fn register<P>(&mut self, provider: P)
+    where
+        P: Provider + 'static,
+    {
+        let id = provider.id().to_string();
+        self.providers.insert(id, Arc::new(provider));
+    }
+
+    /// Get a provider by its ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The unique identifier of the provider
+    ///
+    /// # Returns
+    ///
+    /// An `Option` containing an Arc to the provider if found, or `None` if no
+    /// provider with the given ID is registered.
+    pub fn get(&self, id: &str) -> Option<Arc<dyn Provider>> {
+        self.providers.get(id).cloned()
+    }
+
+    /// List all registered provider IDs.
+    ///
+    /// # Returns
+    ///
+    /// A vector of string slices containing the IDs of all registered providers.
+    pub fn list(&self) -> Vec<&str> {
+        self.providers.keys().map(|s| s.as_str()).collect()
+    }
+
+    /// Get the number of registered providers.
+    pub fn count(&self) -> usize {
+        self.providers.len()
+    }
+
+    /// Check if a provider with the given ID is registered.
+    pub fn contains(&self, id: &str) -> bool {
+        self.providers.contains_key(id)
+    }
+
+    /// Remove a provider from the registry.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The unique identifier of the provider to remove
+    ///
+    /// # Returns
+    ///
+    /// An `Option` containing the removed provider if it existed, or `None` if no
+    /// provider with the given ID was registered.
+    pub fn remove(&mut self, id: &str) -> Option<Arc<dyn Provider>> {
+        self.providers.remove(id)
+    }
+
+    /// Clear all providers from the registry.
+    pub fn clear(&mut self) {
+        self.providers.clear();
+    }
+}
+
+impl Default for ProviderRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+
+    // Mock provider for testing
+    struct MockProvider {
+        id: String,
+    }
+
+    impl MockProvider {
+        fn new(id: &str) -> Self {
+            Self {
+                id: id.to_string(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Provider for MockProvider {
+        fn id(&self) -> &'static str {
+            Box::leak(self.id.clone().into_boxed_str())
+        }
+
+        fn name(&self) -> &'static str {
+            "Mock Provider"
+        }
+
+        async fn health_check(&self) -> Result<ProviderHealth> {
+            Ok(ProviderHealth {
+                is_healthy: true,
+                message: None,
+                last_sync: None,
+                error_count: 0,
+            })
+        }
+
+        async fn sync(&self) -> Result<SyncResult> {
+            Ok(SyncResult {
+                success: true,
+                items_added: 0,
+                items_updated: 0,
+                items_removed: 0,
+                errors: vec![],
+                duration_ms: 0,
+            })
+        }
+
+        fn capabilities(&self) -> ProviderCapabilities {
+            ProviderCapabilities::default()
+        }
+
+        async fn available_actions(&self, _item: &Item) -> Result<Vec<Action>> {
+            Ok(vec![])
+        }
+
+        async fn execute_action(&self, _item: &Item, _action: &Action) -> Result<ActionResult> {
+            Ok(ActionResult {
+                success: true,
+                message: None,
+                data: None,
+            })
+        }
+    }
+
+    #[test]
+    fn test_new_registry() {
+        let registry = ProviderRegistry::new();
+        assert_eq!(registry.count(), 0);
+    }
+
+    #[test]
+    fn test_register_provider() {
+        let mut registry = ProviderRegistry::new();
+        registry.register(MockProvider::new("test"));
+
+        assert_eq!(registry.count(), 1);
+        assert!(registry.contains("test"));
+    }
+
+    #[test]
+    fn test_get_provider() {
+        let mut registry = ProviderRegistry::new();
+        registry.register(MockProvider::new("test"));
+
+        let provider = registry.get("test");
+        assert!(provider.is_some());
+        assert_eq!(provider.unwrap().id(), "test");
+    }
+
+    #[test]
+    fn test_get_nonexistent_provider() {
+        let registry = ProviderRegistry::new();
+        let provider = registry.get("nonexistent");
+        assert!(provider.is_none());
+    }
+
+    #[test]
+    fn test_list_providers() {
+        let mut registry = ProviderRegistry::new();
+        registry.register(MockProvider::new("test1"));
+        registry.register(MockProvider::new("test2"));
+
+        let mut ids = registry.list();
+        ids.sort();
+
+        assert_eq!(ids.len(), 2);
+        assert_eq!(ids[0], "test1");
+        assert_eq!(ids[1], "test2");
+    }
+
+    #[test]
+    fn test_remove_provider() {
+        let mut registry = ProviderRegistry::new();
+        registry.register(MockProvider::new("test"));
+
+        assert_eq!(registry.count(), 1);
+
+        let removed = registry.remove("test");
+        assert!(removed.is_some());
+        assert_eq!(registry.count(), 0);
+    }
+
+    #[test]
+    fn test_clear_registry() {
+        let mut registry = ProviderRegistry::new();
+        registry.register(MockProvider::new("test1"));
+        registry.register(MockProvider::new("test2"));
+
+        assert_eq!(registry.count(), 2);
+
+        registry.clear();
+        assert_eq!(registry.count(), 0);
+    }
+
+    #[test]
+    fn test_replace_provider() {
+        let mut registry = ProviderRegistry::new();
+        registry.register(MockProvider::new("test"));
+
+        assert_eq!(registry.count(), 1);
+
+        // Register another provider with the same ID
+        registry.register(MockProvider::new("test"));
+
+        // Should still have only one provider
+        assert_eq!(registry.count(), 1);
+    }
+}

--- a/scryforge-daemon/tests/registry_test.rs
+++ b/scryforge-daemon/tests/registry_test.rs
@@ -1,0 +1,135 @@
+//! Integration tests for the provider registry.
+//!
+//! These tests verify that the provider registry can load and discover providers,
+//! and that providers can be accessed through the registry.
+
+use provider_dummy::DummyProvider;
+use scryforge_daemon::registry::ProviderRegistry;
+
+#[test]
+fn test_registry_discovery() {
+    let mut registry = ProviderRegistry::new();
+
+    // Initially empty
+    assert_eq!(registry.count(), 0);
+    assert!(registry.list().is_empty());
+
+    // Register dummy provider
+    registry.register(DummyProvider::new());
+
+    // Verify registration
+    assert_eq!(registry.count(), 1);
+    assert!(registry.contains("dummy"));
+
+    let provider_ids = registry.list();
+    assert_eq!(provider_ids.len(), 1);
+    assert_eq!(provider_ids[0], "dummy");
+}
+
+#[test]
+fn test_registry_provider_access() {
+    let mut registry = ProviderRegistry::new();
+    registry.register(DummyProvider::new());
+
+    // Get the provider
+    let provider = registry.get("dummy");
+    assert!(provider.is_some());
+
+    let provider = provider.unwrap();
+    assert_eq!(provider.id(), "dummy");
+    assert_eq!(provider.name(), "Dummy Provider");
+}
+
+#[tokio::test]
+async fn test_registry_provider_health_check() {
+    let mut registry = ProviderRegistry::new();
+    registry.register(DummyProvider::new());
+
+    let provider = registry.get("dummy").unwrap();
+
+    // Health check should succeed
+    let health = provider.health_check().await;
+    assert!(health.is_ok());
+
+    let health = health.unwrap();
+    assert!(health.is_healthy);
+    assert_eq!(health.error_count, 0);
+}
+
+#[tokio::test]
+async fn test_registry_provider_capabilities() {
+    let mut registry = ProviderRegistry::new();
+    registry.register(DummyProvider::new());
+
+    let provider = registry.get("dummy").unwrap();
+
+    // Check capabilities
+    let caps = provider.capabilities();
+    assert!(caps.has_feeds);
+    assert!(!caps.has_collections);
+    assert!(!caps.has_saved_items);
+    assert!(!caps.has_communities);
+}
+
+#[tokio::test]
+async fn test_registry_provider_sync() {
+    let mut registry = ProviderRegistry::new();
+    registry.register(DummyProvider::new());
+
+    let provider = registry.get("dummy").unwrap();
+
+    // Sync should succeed
+    let result = provider.sync().await;
+    assert!(result.is_ok());
+
+    let result = result.unwrap();
+    assert!(result.success);
+    assert_eq!(result.errors.len(), 0);
+}
+
+#[test]
+fn test_registry_multiple_providers() {
+    let mut registry = ProviderRegistry::new();
+
+    // Register multiple instances (in a real scenario, these would be different providers)
+    registry.register(DummyProvider::new());
+
+    // Try to get a non-existent provider
+    let nonexistent = registry.get("nonexistent");
+    assert!(nonexistent.is_none());
+
+    // Verify dummy is still accessible
+    let dummy = registry.get("dummy");
+    assert!(dummy.is_some());
+}
+
+#[test]
+fn test_registry_remove_provider() {
+    let mut registry = ProviderRegistry::new();
+    registry.register(DummyProvider::new());
+
+    assert_eq!(registry.count(), 1);
+
+    // Remove the provider
+    let removed = registry.remove("dummy");
+    assert!(removed.is_some());
+
+    // Verify removal
+    assert_eq!(registry.count(), 0);
+    assert!(!registry.contains("dummy"));
+}
+
+#[test]
+fn test_registry_clear() {
+    let mut registry = ProviderRegistry::new();
+    registry.register(DummyProvider::new());
+
+    assert_eq!(registry.count(), 1);
+
+    // Clear all providers
+    registry.clear();
+
+    // Verify cleared
+    assert_eq!(registry.count(), 0);
+    assert!(registry.list().is_empty());
+}


### PR DESCRIPTION
## Summary
- Created provider-dummy crate implementing Provider + HasFeeds
- Added ProviderRegistry to daemon with provider loading
- Documented provider flow in PROVIDERS.md

## Changes
- `providers/provider-dummy/` - New dummy provider crate
- `scryforge-daemon/src/registry.rs` - Provider registry
- `scryforge-daemon/tests/registry_test.rs` - 8 smoke tests
- `docs/PROVIDERS.md` - Updated with loading flow

## Test plan
- [x] Dummy provider is discoverable via registry
- [x] Registry pattern ready for real providers
- [x] All 24 tests pass

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)