### PR TITLE
feat: Introduce Sigilforge client + auth plumbing (#9)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/fusabi-tui-core",
     "crates/fusabi-tui-widgets",
     "scryforge-daemon",
+    "scryforge-sigilforge-client",
     "scryforge-tui",
     # Provider crates:
     "providers/provider-dummy",
@@ -57,3 +58,4 @@ uuid = { version = "1.10", features = ["v4", "serde"] }
 fusabi-streams-core = { path = "crates/fusabi-streams-core" }
 fusabi-tui-core = { path = "crates/fusabi-tui-core" }
 fusabi-tui-widgets = { path = "crates/fusabi-tui-widgets" }
+scryforge-sigilforge-client = { path = "scryforge-sigilforge-client" }

--- a/crates/fusabi-streams-core/Cargo.toml
+++ b/crates/fusabi-streams-core/Cargo.toml
@@ -14,3 +14,10 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
+
+# Optional: Sigilforge client for auth token management
+scryforge-sigilforge-client = { workspace = true, optional = true }
+
+[features]
+default = []
+sigilforge = ["scryforge-sigilforge-client"]

--- a/crates/fusabi-streams-core/src/lib.rs
+++ b/crates/fusabi-streams-core/src/lib.rs
@@ -9,6 +9,17 @@
 //! - [`Item`] - An entry within a stream (email, article, video, track, etc.)
 //! - [`Action`] - Operations that can be performed on items
 //! - Provider capability traits: [`HasFeeds`], [`HasCollections`], [`HasSavedItems`], [`HasCommunities`]
+//!
+//! ## Authentication
+//!
+//! Providers that require OAuth tokens can use the `TokenFetcher` trait from
+//! `scryforge-sigilforge-client` to fetch credentials from the Sigilforge daemon.
+//! Enable the `sigilforge` feature to access authentication utilities.
+//!
+//! ```toml
+//! [dependencies]
+//! fusabi-streams-core = { version = "0.1", features = ["sigilforge"] }
+//! ```
 
 use async_trait::async_trait;
 use chrono::{DateTime, NaiveDate, Utc};
@@ -442,6 +453,45 @@ pub trait HasCommunities: Provider {
 }
 
 // ============================================================================
+// Authentication Support (Optional)
+// ============================================================================
+
+#[cfg(feature = "sigilforge")]
+pub mod auth {
+    //! Authentication utilities for providers that need OAuth tokens.
+    //!
+    //! This module re-exports types from `scryforge-sigilforge-client` to make it
+    //! easier for providers to request authentication tokens.
+    //!
+    //! # Example
+    //!
+    //! ```no_run
+    //! use fusabi_streams_core::auth::{TokenFetcher, MockTokenFetcher};
+    //! use std::sync::Arc;
+    //!
+    //! struct MyProvider {
+    //!     token_fetcher: Arc<dyn TokenFetcher>,
+    //! }
+    //!
+    //! impl MyProvider {
+    //!     pub fn new(token_fetcher: Arc<dyn TokenFetcher>) -> Self {
+    //!         Self { token_fetcher }
+    //!     }
+    //!
+    //!     pub async fn make_api_call(&self) -> Result<(), Box<dyn std::error::Error>> {
+    //!         let token = self.token_fetcher.fetch_token("spotify", "personal").await?;
+    //!         // Use token for API calls...
+    //!         Ok(())
+    //!     }
+    //! }
+    //! ```
+
+    pub use scryforge_sigilforge_client::{
+        default_socket_path, MockTokenFetcher, SigilforgeClient, SigilforgeError, TokenFetcher,
+    };
+}
+
+// ============================================================================
 // Re-exports
 // ============================================================================
 
@@ -452,4 +502,7 @@ pub mod prelude {
         ItemContent, ItemId, Provider, ProviderCapabilities, ProviderHealth, Result,
         SavedItemsOptions, Stream, StreamError, StreamId, StreamType, SyncResult,
     };
+
+    #[cfg(feature = "sigilforge")]
+    pub use crate::auth;
 }

--- a/scryforge-sigilforge-client/Cargo.toml
+++ b/scryforge-sigilforge-client/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "scryforge-sigilforge-client"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Client library for communicating with Sigilforge auth daemon"
+
+[dependencies]
+tokio = { version = "1.40", features = ["net", "sync", "io-util"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+tracing = "0.1"
+async-trait = "0.1"
+directories = "5.0"
+
+[dev-dependencies]
+tokio = { version = "1.40", features = ["full", "test-util"] }
+tempfile = "3.8"
+mockall = "0.13"

--- a/scryforge-sigilforge-client/README.md
+++ b/scryforge-sigilforge-client/README.md
@@ -1,0 +1,132 @@
+# scryforge-sigilforge-client
+
+Client library for communicating with the [Sigilforge](https://github.com/raibid-labs/sigilforge) auth daemon.
+
+## Overview
+
+This crate provides a Rust client for fetching OAuth tokens from the Sigilforge daemon over Unix sockets. It's designed to be used by Scryforge providers that need to authenticate with external services.
+
+## Features
+
+- **SigilforgeClient** - Connect to Sigilforge daemon and fetch tokens
+- **TokenFetcher trait** - Abstract interface for token retrieval
+- **MockTokenFetcher** - Mock implementation for testing
+- Graceful error handling when daemon is unavailable
+- Configurable socket path
+
+## Usage
+
+### Basic Example
+
+```rust
+use scryforge_sigilforge_client::{SigilforgeClient, TokenFetcher};
+use std::path::PathBuf;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Connect to Sigilforge daemon
+    let client = SigilforgeClient::with_default_path();
+
+    if client.is_available() {
+        // Fetch a token
+        let token = client.fetch_token("spotify", "personal").await?;
+        println!("Token: {}", token);
+    } else {
+        eprintln!("Sigilforge daemon not available");
+    }
+
+    Ok(())
+}
+```
+
+### Provider Example
+
+```rust
+use scryforge_sigilforge_client::TokenFetcher;
+use std::sync::Arc;
+
+struct MyProvider {
+    token_fetcher: Arc<dyn TokenFetcher>,
+}
+
+impl MyProvider {
+    pub fn new(token_fetcher: Arc<dyn TokenFetcher>) -> Self {
+        Self { token_fetcher }
+    }
+
+    pub async fn make_api_call(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let token = self.token_fetcher.fetch_token("spotify", "personal").await?;
+        // Use token for API calls...
+        Ok(())
+    }
+}
+```
+
+### Testing with MockTokenFetcher
+
+```rust
+use scryforge_sigilforge_client::{MockTokenFetcher, TokenFetcher};
+use std::collections::HashMap;
+
+#[tokio::test]
+async fn test_provider() {
+    let fetcher = MockTokenFetcher::empty()
+        .with_token("spotify".into(), "personal".into(), "test_token".into());
+
+    let token = fetcher.fetch_token("spotify", "personal").await.unwrap();
+    assert_eq!(token, "test_token");
+}
+```
+
+## Configuration
+
+The default socket path is platform-dependent:
+
+- **Unix**: `$XDG_RUNTIME_DIR/sigilforge.sock` or `/tmp/sigilforge.sock`
+- **Windows**: `\\.\pipe\sigilforge`
+
+You can override the path when creating the client:
+
+```rust
+let client = SigilforgeClient::new(PathBuf::from("/custom/path/sigilforge.sock"));
+```
+
+## Error Handling
+
+The client provides graceful error handling:
+
+```rust
+use scryforge_sigilforge_client::{SigilforgeClient, SigilforgeError};
+
+let client = SigilforgeClient::with_default_path();
+
+match client.get_token("spotify", "personal").await {
+    Ok(token) => println!("Token: {}", token),
+    Err(SigilforgeError::Unavailable(msg)) => {
+        eprintln!("Daemon not available: {}", msg);
+    },
+    Err(SigilforgeError::TokenNotFound { service, account }) => {
+        eprintln!("Token not found for {}/{}", service, account);
+    },
+    Err(e) => eprintln!("Error: {}", e),
+}
+```
+
+## Integration with fusabi-streams-core
+
+Providers can use this crate through `fusabi-streams-core` by enabling the `sigilforge` feature:
+
+```toml
+[dependencies]
+fusabi-streams-core = { version = "0.1", features = ["sigilforge"] }
+```
+
+Then use the `auth` module:
+
+```rust
+use fusabi_streams_core::auth::{TokenFetcher, SigilforgeClient};
+```
+
+## License
+
+MIT OR Apache-2.0

--- a/scryforge-sigilforge-client/examples/provider_example.rs
+++ b/scryforge-sigilforge-client/examples/provider_example.rs
@@ -1,0 +1,135 @@
+//! Example provider implementation demonstrating TokenFetcher usage.
+//!
+//! This example shows how a provider can use the TokenFetcher trait to
+//! request authentication tokens from the Sigilforge daemon.
+
+use scryforge_sigilforge_client::{MockTokenFetcher, SigilforgeClient, TokenFetcher};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Example provider that requires OAuth authentication.
+struct SpotifyProvider {
+    service_name: &'static str,
+    account_name: String,
+    token_fetcher: Arc<dyn TokenFetcher>,
+}
+
+impl SpotifyProvider {
+    /// Create a new provider with the given token fetcher.
+    pub fn new(account_name: String, token_fetcher: Arc<dyn TokenFetcher>) -> Self {
+        Self {
+            service_name: "spotify",
+            account_name,
+            token_fetcher,
+        }
+    }
+
+    /// Simulate fetching playlists from Spotify API.
+    pub async fn fetch_playlists(&self) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+        // Request a fresh OAuth token
+        let token = self
+            .token_fetcher
+            .fetch_token(self.service_name, &self.account_name)
+            .await?;
+
+        println!("Got token for {}: {}", self.account_name, token);
+
+        // In a real implementation, use the token to make API calls
+        // For this example, just return mock data
+        Ok(vec![
+            "Discover Weekly".to_string(),
+            "Release Radar".to_string(),
+            "Liked Songs".to_string(),
+        ])
+    }
+
+    /// Simulate playing a track.
+    pub async fn play_track(&self, track_id: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let token = self
+            .token_fetcher
+            .fetch_token(self.service_name, &self.account_name)
+            .await?;
+
+        println!("Playing track {} with token: {}", track_id, token);
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("=== Sigilforge Client Provider Example ===\n");
+
+    // Example 1: Using a real Sigilforge client
+    println!("Example 1: Real Sigilforge client (will fail if daemon not running)");
+    let real_client = SigilforgeClient::with_default_path();
+
+    if real_client.is_available() {
+        println!("  Sigilforge daemon is available!");
+        let provider = SpotifyProvider::new("personal".to_string(), Arc::new(real_client));
+
+        match provider.fetch_playlists().await {
+            Ok(playlists) => {
+                println!("  Playlists: {:?}", playlists);
+            }
+            Err(e) => {
+                println!("  Error fetching playlists: {}", e);
+            }
+        }
+    } else {
+        println!("  Sigilforge daemon is NOT available (socket not found)");
+        println!("  This is expected if the daemon is not running.\n");
+    }
+
+    // Example 2: Using a mock token fetcher for testing
+    println!("\nExample 2: Mock token fetcher (for testing)");
+    let mut tokens = HashMap::new();
+    tokens.insert(
+        ("spotify".to_string(), "personal".to_string()),
+        "mock_access_token_abc123".to_string(),
+    );
+    tokens.insert(
+        ("spotify".to_string(), "work".to_string()),
+        "mock_access_token_xyz789".to_string(),
+    );
+
+    let mock_fetcher = MockTokenFetcher::new(tokens);
+
+    let provider1 = SpotifyProvider::new("personal".to_string(), Arc::new(mock_fetcher.clone()));
+    let playlists = provider1.fetch_playlists().await?;
+    println!("  Personal playlists: {:?}", playlists);
+
+    let provider2 = SpotifyProvider::new("work".to_string(), Arc::new(mock_fetcher.clone()));
+    provider2.play_track("track_12345").await?;
+
+    // Example 3: Using builder pattern with MockTokenFetcher
+    println!("\nExample 3: Mock token fetcher with builder pattern");
+    let builder_fetcher = MockTokenFetcher::empty()
+        .with_token(
+            "spotify".to_string(),
+            "test".to_string(),
+            "builder_token_123".to_string(),
+        )
+        .with_token(
+            "github".to_string(),
+            "test".to_string(),
+            "builder_token_456".to_string(),
+        );
+
+    let provider3 = SpotifyProvider::new("test".to_string(), Arc::new(builder_fetcher));
+    let playlists = provider3.fetch_playlists().await?;
+    println!("  Test playlists: {:?}", playlists);
+
+    // Example 4: Handling token not found
+    println!("\nExample 4: Handling missing tokens");
+    let empty_fetcher = MockTokenFetcher::empty();
+    let provider4 = SpotifyProvider::new("missing".to_string(), Arc::new(empty_fetcher));
+
+    match provider4.fetch_playlists().await {
+        Ok(_) => println!("  Unexpected success!"),
+        Err(e) => println!("  Expected error: {}", e),
+    }
+
+    println!("\n=== Example Complete ===");
+
+    Ok(())
+}

--- a/scryforge-sigilforge-client/src/lib.rs
+++ b/scryforge-sigilforge-client/src/lib.rs
@@ -1,0 +1,459 @@
+//! # scryforge-sigilforge-client
+//!
+//! Client library for communicating with the Sigilforge auth daemon.
+//!
+//! This crate provides:
+//! - [`SigilforgeClient`] - Client for fetching tokens from Sigilforge daemon
+//! - [`TokenFetcher`] - Trait for components that need auth tokens
+//! - [`MockTokenFetcher`] - Mock implementation for testing
+//!
+//! ## Example
+//!
+//! ```no_run
+//! use scryforge_sigilforge_client::{SigilforgeClient, TokenFetcher};
+//! use std::path::PathBuf;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = SigilforgeClient::new(PathBuf::from("/tmp/sigilforge.sock"));
+//!
+//! if client.is_available() {
+//!     let token = client.fetch_token("spotify", "personal").await?;
+//!     println!("Got token: {}", token);
+//! } else {
+//!     eprintln!("Sigilforge daemon not available");
+//! }
+//! # Ok(())
+//! # }
+//! ```
+
+use async_trait::async_trait;
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tracing::debug;
+
+// ============================================================================
+// Error Types
+// ============================================================================
+
+#[derive(Debug, Error)]
+pub enum SigilforgeError {
+    #[error("Sigilforge daemon not available: {0}")]
+    Unavailable(String),
+
+    #[error("Token not found for {service}/{account}")]
+    TokenNotFound { service: String, account: String },
+
+    #[error("Connection error: {0}")]
+    Connection(String),
+
+    #[error("RPC error: {0}")]
+    Rpc(String),
+
+    #[error("Serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Invalid response: {0}")]
+    InvalidResponse(String),
+}
+
+pub type Result<T> = std::result::Result<T, SigilforgeError>;
+
+// ============================================================================
+// Response Types
+// ============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GetTokenResponse {
+    token: String,
+    expires_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ResolveResponse {
+    value: String,
+}
+
+// ============================================================================
+// Client Implementation
+// ============================================================================
+
+/// Client for communicating with Sigilforge daemon over Unix socket.
+///
+/// The client maintains a connection to the Sigilforge daemon and provides
+/// methods to fetch OAuth tokens and resolve credential references.
+#[derive(Debug)]
+pub struct SigilforgeClient {
+    socket_path: PathBuf,
+}
+
+impl SigilforgeClient {
+    /// Create a new Sigilforge client with the specified socket path.
+    ///
+    /// # Arguments
+    ///
+    /// * `socket_path` - Path to the Sigilforge daemon Unix socket
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use scryforge_sigilforge_client::SigilforgeClient;
+    /// use std::path::PathBuf;
+    ///
+    /// let client = SigilforgeClient::new(PathBuf::from("/tmp/sigilforge.sock"));
+    /// ```
+    pub fn new(socket_path: PathBuf) -> Self {
+        Self { socket_path }
+    }
+
+    /// Create a new client using the default socket path.
+    ///
+    /// The default path is determined by the platform:
+    /// - Unix: `$XDG_RUNTIME_DIR/sigilforge.sock` or `/tmp/sigilforge.sock`
+    /// - Windows: `\\.\pipe\sigilforge`
+    pub fn with_default_path() -> Self {
+        Self {
+            socket_path: default_socket_path(),
+        }
+    }
+
+    /// Check if the Sigilforge daemon is available.
+    ///
+    /// Returns `true` if the socket file exists, `false` otherwise.
+    /// Note: This doesn't guarantee the daemon is actually running.
+    pub fn is_available(&self) -> bool {
+        self.socket_path.exists()
+    }
+
+    /// Get the socket path being used by this client.
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+
+    /// Get a fresh access token for the specified service and account.
+    ///
+    /// # Arguments
+    ///
+    /// * `service` - Service identifier (e.g., "spotify", "github")
+    /// * `account` - Account identifier (e.g., "personal", "work")
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The daemon is not available
+    /// - The connection fails
+    /// - The account is not found
+    /// - The RPC call fails
+    pub async fn get_token(&self, service: &str, account: &str) -> Result<String> {
+        if !self.is_available() {
+            return Err(SigilforgeError::Unavailable(format!(
+                "Socket not found at {:?}",
+                self.socket_path
+            )));
+        }
+
+        let response: GetTokenResponse = self
+            .send_request("get_token", json!([service, account]))
+            .await
+            .map_err(|e| {
+                if e.to_string().contains("not found") {
+                    SigilforgeError::TokenNotFound {
+                        service: service.to_string(),
+                        account: account.to_string(),
+                    }
+                } else {
+                    e
+                }
+            })?;
+
+        Ok(response.token)
+    }
+
+    /// Resolve a credential reference to its actual value.
+    ///
+    /// # Arguments
+    ///
+    /// * `reference` - Credential reference (e.g., "auth://spotify/personal/token")
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The daemon is not available
+    /// - The reference is invalid
+    /// - The credential is not found
+    pub async fn resolve(&self, reference: &str) -> Result<String> {
+        if !self.is_available() {
+            return Err(SigilforgeError::Unavailable(format!(
+                "Socket not found at {:?}",
+                self.socket_path
+            )));
+        }
+
+        let response: ResolveResponse = self.send_request("resolve", json!([reference])).await?;
+        Ok(response.value)
+    }
+
+    /// Send a JSON-RPC request and receive a typed response.
+    async fn send_request<T>(&self, method: &str, params: serde_json::Value) -> Result<T>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        // Connect to the daemon
+        let mut stream = UnixStream::connect(&self.socket_path)
+            .await
+            .map_err(|e| {
+                SigilforgeError::Connection(format!(
+                    "Failed to connect to {:?}: {}",
+                    self.socket_path, e
+                ))
+            })?;
+
+        debug!("Connected to Sigilforge daemon at {:?}", self.socket_path);
+
+        // Prepare JSON-RPC request
+        let request = json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+            "id": 1,
+        });
+
+        let request_str = serde_json::to_string(&request)?;
+        debug!("Sending request: {}", request_str);
+
+        // Send request
+        stream.write_all(request_str.as_bytes()).await?;
+        stream.write_all(b"\n").await?;
+        stream.flush().await?;
+
+        // Read response
+        let mut reader = BufReader::new(&mut stream);
+        let mut response_str = String::new();
+        reader.read_line(&mut response_str).await?;
+
+        debug!("Received response: {}", response_str.trim());
+
+        // Parse response
+        let response: serde_json::Value = serde_json::from_str(&response_str)?;
+
+        // Check for errors
+        if let Some(error) = response.get("error") {
+            let error_msg = error
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("Unknown error");
+            return Err(SigilforgeError::Rpc(error_msg.to_string()));
+        }
+
+        // Extract result
+        let result = response
+            .get("result")
+            .ok_or_else(|| SigilforgeError::InvalidResponse("No result field".to_string()))?;
+
+        Ok(serde_json::from_value(result.clone())?)
+    }
+}
+
+// ============================================================================
+// TokenFetcher Trait
+// ============================================================================
+
+/// Trait for components that need to fetch authentication tokens.
+///
+/// This trait provides an abstraction for token fetching, allowing
+/// providers to request credentials without being coupled to the
+/// Sigilforge implementation.
+#[async_trait]
+pub trait TokenFetcher: Send + Sync {
+    /// Fetch an authentication token for the specified service and account.
+    ///
+    /// # Arguments
+    ///
+    /// * `service` - Service identifier (e.g., "spotify", "github")
+    /// * `account` - Account identifier (e.g., "personal", "work")
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the token cannot be fetched.
+    async fn fetch_token(&self, service: &str, account: &str) -> Result<String>;
+}
+
+#[async_trait]
+impl TokenFetcher for SigilforgeClient {
+    async fn fetch_token(&self, service: &str, account: &str) -> Result<String> {
+        self.get_token(service, account).await
+    }
+}
+
+// ============================================================================
+// Mock Implementation for Testing
+// ============================================================================
+
+/// Mock token fetcher for testing purposes.
+///
+/// This implementation returns pre-configured tokens without
+/// connecting to an actual Sigilforge daemon.
+///
+/// # Example
+///
+/// ```
+/// use scryforge_sigilforge_client::{MockTokenFetcher, TokenFetcher};
+/// use std::collections::HashMap;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut tokens = HashMap::new();
+/// tokens.insert(
+///     ("spotify".to_string(), "personal".to_string()),
+///     "test_token_123".to_string()
+/// );
+///
+/// let fetcher = MockTokenFetcher::new(tokens);
+/// let token = fetcher.fetch_token("spotify", "personal").await?;
+/// assert_eq!(token, "test_token_123");
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct MockTokenFetcher {
+    tokens: HashMap<(String, String), String>,
+}
+
+impl MockTokenFetcher {
+    /// Create a new mock token fetcher with the given tokens.
+    ///
+    /// # Arguments
+    ///
+    /// * `tokens` - Map of (service, account) to token value
+    pub fn new(tokens: HashMap<(String, String), String>) -> Self {
+        Self { tokens }
+    }
+
+    /// Create an empty mock token fetcher.
+    pub fn empty() -> Self {
+        Self {
+            tokens: HashMap::new(),
+        }
+    }
+
+    /// Add a token to the mock fetcher.
+    pub fn with_token(mut self, service: String, account: String, token: String) -> Self {
+        self.tokens.insert((service, account), token);
+        self
+    }
+}
+
+#[async_trait]
+impl TokenFetcher for MockTokenFetcher {
+    async fn fetch_token(&self, service: &str, account: &str) -> Result<String> {
+        self.tokens
+            .get(&(service.to_string(), account.to_string()))
+            .cloned()
+            .ok_or_else(|| SigilforgeError::TokenNotFound {
+                service: service.to_string(),
+                account: account.to_string(),
+            })
+    }
+}
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/// Get the default socket path for the Sigilforge daemon.
+///
+/// The path is platform-dependent:
+/// - Unix: `$XDG_RUNTIME_DIR/sigilforge.sock` or `/tmp/sigilforge.sock`
+/// - Windows: `\\.\pipe\sigilforge`
+pub fn default_socket_path() -> PathBuf {
+    let dirs = ProjectDirs::from("com", "raibid-labs", "sigilforge");
+
+    if cfg!(unix) {
+        dirs.as_ref()
+            .and_then(|d| d.runtime_dir())
+            .map(|d| d.join("sigilforge.sock"))
+            .unwrap_or_else(|| PathBuf::from("/tmp/sigilforge.sock"))
+    } else {
+        PathBuf::from(r"\\.\pipe\sigilforge")
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_socket_path() {
+        let path = default_socket_path();
+        assert!(!path.as_os_str().is_empty());
+    }
+
+    #[test]
+    fn test_client_creation() {
+        let client = SigilforgeClient::new(PathBuf::from("/tmp/test.sock"));
+        assert_eq!(client.socket_path(), Path::new("/tmp/test.sock"));
+    }
+
+    #[test]
+    fn test_client_with_default_path() {
+        let client = SigilforgeClient::with_default_path();
+        assert!(!client.socket_path().as_os_str().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_mock_token_fetcher() {
+        let mut tokens = HashMap::new();
+        tokens.insert(
+            ("spotify".to_string(), "personal".to_string()),
+            "test_token_123".to_string(),
+        );
+
+        let fetcher = MockTokenFetcher::new(tokens);
+        let token = fetcher.fetch_token("spotify", "personal").await.unwrap();
+        assert_eq!(token, "test_token_123");
+
+        let result = fetcher.fetch_token("github", "work").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_mock_token_fetcher_builder() {
+        let fetcher = MockTokenFetcher::empty()
+            .with_token(
+                "spotify".to_string(),
+                "personal".to_string(),
+                "token1".to_string(),
+            )
+            .with_token(
+                "github".to_string(),
+                "work".to_string(),
+                "token2".to_string(),
+            );
+
+        let token1 = fetcher.fetch_token("spotify", "personal").await.unwrap();
+        assert_eq!(token1, "token1");
+
+        let token2 = fetcher.fetch_token("github", "work").await.unwrap();
+        assert_eq!(token2, "token2");
+    }
+
+    #[tokio::test]
+    async fn test_client_unavailable() {
+        let client = SigilforgeClient::new(PathBuf::from("/nonexistent/socket.sock"));
+        assert!(!client.is_available());
+
+        let result = client.get_token("spotify", "personal").await;
+        assert!(matches!(result, Err(SigilforgeError::Unavailable(_))));
+    }
+}

--- a/scryforge-sigilforge-client/tests/contract_tests.rs
+++ b/scryforge-sigilforge-client/tests/contract_tests.rs
@@ -1,0 +1,320 @@
+//! Contract tests for Sigilforge client.
+//!
+//! These tests verify the client's behavior with both real and mocked
+//! Sigilforge daemon responses.
+
+use scryforge_sigilforge_client::{MockTokenFetcher, SigilforgeClient, SigilforgeError, TokenFetcher};
+use serde_json::json;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use tempfile::TempDir;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+
+// ============================================================================
+// Mock Server Helpers
+// ============================================================================
+
+/// Start a mock Sigilforge daemon that responds to get_token requests.
+async fn start_mock_daemon(
+    socket_path: PathBuf,
+    tokens: HashMap<(String, String), String>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let listener = UnixListener::bind(&socket_path).expect("Failed to bind socket");
+
+        loop {
+            match listener.accept().await {
+                Ok((mut stream, _)) => {
+                    let tokens = tokens.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_mock_connection(&mut stream, tokens).await {
+                            eprintln!("Mock daemon error: {}", e);
+                        }
+                    });
+                }
+                Err(e) => {
+                    eprintln!("Accept error: {}", e);
+                    break;
+                }
+            }
+        }
+    })
+}
+
+/// Handle a single connection to the mock daemon.
+async fn handle_mock_connection(
+    stream: &mut UnixStream,
+    tokens: HashMap<(String, String), String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut reader = BufReader::new(stream);
+    let mut request_line = String::new();
+
+    reader.read_line(&mut request_line).await?;
+
+    let request: serde_json::Value = serde_json::from_str(&request_line)?;
+    let method = request["method"].as_str().unwrap_or("");
+    let empty_params = vec![];
+    let params = request["params"].as_array().unwrap_or(&empty_params);
+    let id = request["id"].clone();
+
+    let response = match method {
+        "get_token" => {
+            let service = params
+                .get(0)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let account = params
+                .get(1)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+
+            if let Some(token) = tokens.get(&(service.clone(), account.clone())) {
+                json!({
+                    "jsonrpc": "2.0",
+                    "result": {
+                        "token": token,
+                        "expires_at": "2025-12-07T00:00:00Z"
+                    },
+                    "id": id
+                })
+            } else {
+                json!({
+                    "jsonrpc": "2.0",
+                    "error": {
+                        "code": -32602,
+                        "message": format!("Account {}/{} not found", service, account)
+                    },
+                    "id": id
+                })
+            }
+        }
+        "resolve" => {
+            let reference = params.get(0).and_then(|v| v.as_str()).unwrap_or("");
+            json!({
+                "jsonrpc": "2.0",
+                "result": {
+                    "value": format!("resolved_{}", reference)
+                },
+                "id": id
+            })
+        }
+        _ => json!({
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32601,
+                "message": "Method not found"
+            },
+            "id": id
+        }),
+    };
+
+    let response_str = serde_json::to_string(&response)?;
+    reader.get_mut().write_all(response_str.as_bytes()).await?;
+    reader.get_mut().write_all(b"\n").await?;
+    reader.get_mut().flush().await?;
+
+    Ok(())
+}
+
+// ============================================================================
+// Contract Tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_client_unavailable_returns_error() {
+    let client = SigilforgeClient::new(PathBuf::from("/nonexistent/socket.sock"));
+
+    assert!(!client.is_available());
+
+    let result = client.get_token("spotify", "personal").await;
+    assert!(matches!(result, Err(SigilforgeError::Unavailable(_))));
+}
+
+#[tokio::test]
+async fn test_client_fetch_token_success() {
+    let temp_dir = TempDir::new().unwrap();
+    let socket_path = temp_dir.path().join("test.sock");
+
+    let mut tokens = HashMap::new();
+    tokens.insert(
+        ("spotify".to_string(), "personal".to_string()),
+        "test_access_token_123".to_string(),
+    );
+
+    let _server = start_mock_daemon(socket_path.clone(), tokens).await;
+
+    // Give server time to start
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    let client = SigilforgeClient::new(socket_path);
+    assert!(client.is_available());
+
+    let token = client.get_token("spotify", "personal").await.unwrap();
+    assert_eq!(token, "test_access_token_123");
+}
+
+#[tokio::test]
+async fn test_client_token_not_found() {
+    let temp_dir = TempDir::new().unwrap();
+    let socket_path = temp_dir.path().join("test.sock");
+
+    let tokens = HashMap::new();
+    let _server = start_mock_daemon(socket_path.clone(), tokens).await;
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    let client = SigilforgeClient::new(socket_path);
+
+    let result = client.get_token("github", "work").await;
+    assert!(matches!(result, Err(SigilforgeError::TokenNotFound { .. })));
+}
+
+#[tokio::test]
+async fn test_client_resolve_reference() {
+    let temp_dir = TempDir::new().unwrap();
+    let socket_path = temp_dir.path().join("test.sock");
+
+    let tokens = HashMap::new();
+    let _server = start_mock_daemon(socket_path.clone(), tokens).await;
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    let client = SigilforgeClient::new(socket_path);
+
+    let value = client
+        .resolve("auth://spotify/personal/token")
+        .await
+        .unwrap();
+    assert_eq!(value, "resolved_auth://spotify/personal/token");
+}
+
+#[tokio::test]
+async fn test_token_fetcher_trait_impl() {
+    let temp_dir = TempDir::new().unwrap();
+    let socket_path = temp_dir.path().join("test.sock");
+
+    let mut tokens = HashMap::new();
+    tokens.insert(
+        ("spotify".to_string(), "personal".to_string()),
+        "trait_test_token".to_string(),
+    );
+
+    let _server = start_mock_daemon(socket_path.clone(), tokens).await;
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    let client = SigilforgeClient::new(socket_path);
+    let fetcher: &dyn TokenFetcher = &client;
+
+    let token = fetcher.fetch_token("spotify", "personal").await.unwrap();
+    assert_eq!(token, "trait_test_token");
+}
+
+#[tokio::test]
+async fn test_mock_token_fetcher_success() {
+    let mut tokens = HashMap::new();
+    tokens.insert(
+        ("spotify".to_string(), "personal".to_string()),
+        "mock_token_abc".to_string(),
+    );
+    tokens.insert(
+        ("github".to_string(), "work".to_string()),
+        "mock_token_xyz".to_string(),
+    );
+
+    let fetcher = MockTokenFetcher::new(tokens);
+
+    let token1 = fetcher.fetch_token("spotify", "personal").await.unwrap();
+    assert_eq!(token1, "mock_token_abc");
+
+    let token2 = fetcher.fetch_token("github", "work").await.unwrap();
+    assert_eq!(token2, "mock_token_xyz");
+}
+
+#[tokio::test]
+async fn test_mock_token_fetcher_not_found() {
+    let fetcher = MockTokenFetcher::empty();
+
+    let result = fetcher.fetch_token("spotify", "personal").await;
+    assert!(matches!(result, Err(SigilforgeError::TokenNotFound { .. })));
+}
+
+#[tokio::test]
+async fn test_mock_token_fetcher_builder() {
+    let fetcher = MockTokenFetcher::empty()
+        .with_token(
+            "spotify".to_string(),
+            "personal".to_string(),
+            "builder_token_1".to_string(),
+        )
+        .with_token(
+            "github".to_string(),
+            "work".to_string(),
+            "builder_token_2".to_string(),
+        );
+
+    let token1 = fetcher.fetch_token("spotify", "personal").await.unwrap();
+    assert_eq!(token1, "builder_token_1");
+
+    let token2 = fetcher.fetch_token("github", "work").await.unwrap();
+    assert_eq!(token2, "builder_token_2");
+}
+
+#[tokio::test]
+async fn test_multiple_requests() {
+    let temp_dir = TempDir::new().unwrap();
+    let socket_path = temp_dir.path().join("test.sock");
+
+    let mut tokens = HashMap::new();
+    tokens.insert(
+        ("spotify".to_string(), "personal".to_string()),
+        "token_1".to_string(),
+    );
+    tokens.insert(
+        ("github".to_string(), "work".to_string()),
+        "token_2".to_string(),
+    );
+
+    let _server = start_mock_daemon(socket_path.clone(), tokens).await;
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    let client = SigilforgeClient::new(socket_path);
+
+    let token1 = client.get_token("spotify", "personal").await.unwrap();
+    assert_eq!(token1, "token_1");
+
+    let token2 = client.get_token("github", "work").await.unwrap();
+    assert_eq!(token2, "token_2");
+
+    // Verify we can fetch the same token again
+    let token1_again = client.get_token("spotify", "personal").await.unwrap();
+    assert_eq!(token1_again, "token_1");
+}
+
+#[tokio::test]
+async fn test_graceful_error_when_daemon_stops() {
+    let temp_dir = TempDir::new().unwrap();
+    let socket_path = temp_dir.path().join("test.sock");
+
+    let tokens = HashMap::new();
+    let server = start_mock_daemon(socket_path.clone(), tokens).await;
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    let client = SigilforgeClient::new(socket_path.clone());
+    assert!(client.is_available());
+
+    // Stop the server
+    server.abort();
+    std::fs::remove_file(&socket_path).ok();
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Client should detect daemon is unavailable
+    assert!(!client.is_available());
+
+    let result = client.get_token("spotify", "personal").await;
+    assert!(matches!(result, Err(SigilforgeError::Unavailable(_))));
+}


### PR DESCRIPTION
## Summary
- Added scryforge-sigilforge-client crate for token fetching
- Implemented TokenFetcher trait for provider auth
- Added MockTokenFetcher for testing

## Changes
- `scryforge-sigilforge-client/` - New client crate (459 lines)
- `crates/fusabi-streams-core/` - Optional sigilforge feature
- Contract tests and examples included

## Test plan
- [x] Providers can fetch tokens via Sigilforge client
- [x] Graceful error when Sigilforge unavailable
- [x] Socket path configurable
- [x] All 19 tests pass

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)