### PR TITLE
feat(tui): Add playlist picker modal widget

### DIFF
--- a/crates/fusabi-tui-widgets/src/lib.rs
+++ b/crates/fusabi-tui-widgets/src/lib.rs
@@ -40,6 +40,12 @@ pub use theme::Theme;
 // Time Utilities
 // ============================================================================
 pub mod time;
+
+// ============================================================================
+// Playlist Picker
+// ============================================================================
+pub mod playlist_picker;
+
 // ============================================================================
 // Provider Status
 // ============================================================================
@@ -814,6 +820,7 @@ impl<'a> ToastWidget<'a> {
 
 pub mod prelude {
     pub use crate::{
+        playlist_picker::{PlaylistPicker, PlaylistPickerState},
         time, ItemListWidget, OmnibarWidget, PreviewWidget, ProviderStatus, ProviderSyncStatus,
         StatusBarWidget, StreamListWidget, Theme, Toast, ToastType, ToastWidget,
     };

--- a/crates/fusabi-tui-widgets/src/playlist_picker.rs
+++ b/crates/fusabi-tui-widgets/src/playlist_picker.rs
@@ -1,0 +1,251 @@
+//! Playlist picker modal widget.
+//!
+//! A modal dialog for selecting a playlist to add items to.
+
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
+    Frame,
+};
+use scryforge_provider_core::Collection;
+
+use crate::Theme;
+
+/// State for the playlist picker.
+#[derive(Debug, Default)]
+pub struct PlaylistPickerState {
+    /// Currently selected index
+    pub selected: Option<usize>,
+    /// Total number of items
+    len: usize,
+    /// Whether the picker is visible
+    pub visible: bool,
+}
+
+impl PlaylistPickerState {
+    pub fn new(len: usize) -> Self {
+        Self {
+            selected: if len > 0 { Some(0) } else { None },
+            len,
+            visible: false,
+        }
+    }
+
+    pub fn show(&mut self) {
+        self.visible = true;
+    }
+
+    pub fn hide(&mut self) {
+        self.visible = false;
+    }
+
+    pub fn select_next(&mut self) {
+        if self.len == 0 {
+            return;
+        }
+        self.selected = Some(match self.selected {
+            Some(i) => (i + 1) % self.len,
+            None => 0,
+        });
+    }
+
+    pub fn select_prev(&mut self) {
+        if self.len == 0 {
+            return;
+        }
+        self.selected = Some(match self.selected {
+            Some(0) => self.len - 1,
+            Some(i) => i - 1,
+            None => 0,
+        });
+    }
+
+    pub fn update_len(&mut self, len: usize) {
+        self.len = len;
+        if let Some(selected) = self.selected {
+            if selected >= len {
+                self.selected = if len > 0 { Some(len - 1) } else { None };
+            }
+        }
+    }
+}
+
+/// Playlist picker modal widget.
+pub struct PlaylistPicker<'a> {
+    playlists: &'a [Collection],
+    state: &'a PlaylistPickerState,
+    theme: &'a Theme,
+    title: &'a str,
+}
+
+impl<'a> PlaylistPicker<'a> {
+    pub fn new(
+        playlists: &'a [Collection],
+        state: &'a PlaylistPickerState,
+        theme: &'a Theme,
+    ) -> Self {
+        Self {
+            playlists,
+            state,
+            theme,
+            title: "Add to Playlist",
+        }
+    }
+
+    pub fn title(mut self, title: &'a str) -> Self {
+        self.title = title;
+        self
+    }
+
+    /// Calculate centered modal area.
+    fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+        let popup_layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Percentage((100 - percent_y) / 2),
+                Constraint::Percentage(percent_y),
+                Constraint::Percentage((100 - percent_y) / 2),
+            ])
+            .split(area);
+
+        Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Percentage((100 - percent_x) / 2),
+                Constraint::Percentage(percent_x),
+                Constraint::Percentage((100 - percent_x) / 2),
+            ])
+            .split(popup_layout[1])[1]
+    }
+
+    pub fn render(self, frame: &mut Frame, area: Rect) {
+        if !self.state.visible {
+            return;
+        }
+
+        // Calculate modal area (40% width, 50% height, centered)
+        let modal_area = Self::centered_rect(40, 50, area);
+
+        // Clear the background
+        frame.render_widget(Clear, modal_area);
+
+        // Create the modal block
+        let block = Block::default()
+            .title(format!(" {} ", self.title))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(self.theme.border_focused))
+            .style(Style::default().bg(self.theme.background));
+
+        // Create list items
+        let items: Vec<ListItem> = self
+            .playlists
+            .iter()
+            .enumerate()
+            .map(|(i, playlist)| {
+                let is_selected = self.state.selected == Some(i);
+                let icon = if is_selected { "▶ " } else { "  " };
+                let count = format!(" ({} items)", playlist.item_count);
+
+                let style = if is_selected {
+                    Style::default()
+                        .fg(self.theme.accent)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(self.theme.foreground)
+                };
+
+                ListItem::new(Line::from(vec![
+                    Span::styled(icon, style),
+                    Span::styled(&playlist.name, style),
+                    Span::styled(count, Style::default().fg(self.theme.muted)),
+                ]))
+            })
+            .collect();
+
+        // Add "Create New" option
+        let mut all_items = items;
+        let create_new_selected = self.state.selected == Some(self.playlists.len());
+        let create_style = if create_new_selected {
+            Style::default()
+                .fg(self.theme.accent)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(self.theme.muted)
+        };
+        all_items.push(ListItem::new(Line::from(vec![
+            Span::styled("─".repeat(20), Style::default().fg(self.theme.border)),
+        ])));
+        all_items.push(ListItem::new(Line::from(vec![
+            Span::styled(if create_new_selected { "▶ " } else { "  " }, create_style),
+            Span::styled("+ Create New Playlist...", create_style),
+        ])));
+
+        let list = List::new(all_items).block(block);
+
+        frame.render_widget(list, modal_area);
+
+        // Render help text at bottom
+        let help_area = Rect {
+            x: modal_area.x,
+            y: modal_area.y + modal_area.height,
+            width: modal_area.width,
+            height: 1,
+        };
+        if help_area.y < area.height {
+            let help = Paragraph::new(Line::from(vec![
+                Span::styled("j/k", Style::default().fg(self.theme.accent)),
+                Span::raw(": navigate  "),
+                Span::styled("Enter", Style::default().fg(self.theme.accent)),
+                Span::raw(": select  "),
+                Span::styled("Esc", Style::default().fg(self.theme.accent)),
+                Span::raw(": cancel"),
+            ]))
+            .style(Style::default().fg(self.theme.muted));
+            frame.render_widget(help, help_area);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scryforge_provider_core::CollectionId;
+
+    #[test]
+    fn test_picker_state_navigation() {
+        let mut state = PlaylistPickerState::new(3);
+        assert_eq!(state.selected, Some(0));
+
+        state.select_next();
+        assert_eq!(state.selected, Some(1));
+
+        state.select_next();
+        assert_eq!(state.selected, Some(2));
+
+        state.select_next();
+        assert_eq!(state.selected, Some(0)); // Wraps around
+
+        state.select_prev();
+        assert_eq!(state.selected, Some(2)); // Wraps around backward
+    }
+
+    #[test]
+    fn test_picker_visibility() {
+        let mut state = PlaylistPickerState::new(2);
+        assert!(!state.visible);
+
+        state.show();
+        assert!(state.visible);
+
+        state.hide();
+        assert!(!state.visible);
+    }
+
+    #[test]
+    fn test_empty_picker() {
+        let state = PlaylistPickerState::new(0);
+        assert_eq!(state.selected, None);
+    }
+}

--- a/providers/provider-youtube/src/lib.rs
+++ b/providers/provider-youtube/src/lib.rs
@@ -1716,4 +1716,52 @@ mod tests {
             panic!("Expected data in result");
         }
     }
+
+    #[test]
+    fn test_find_download_tool() {
+        // This test just validates the function runs without panic
+        // Actual result depends on system configuration
+        let _result = YouTubeProvider::find_download_tool();
+    }
+
+    #[test]
+    fn test_generate_download_command() {
+        assert_eq!(
+            YouTubeProvider::generate_download_command(
+                "yt-dlp",
+                "https://youtube.com/watch?v=abc123"
+            ),
+            "yt-dlp \"https://youtube.com/watch?v=abc123\""
+        );
+    }
+
+    fn create_test_video_item() -> Item {
+        Item {
+            id: ItemId::new("youtube", "test-video"),
+            stream_id: StreamId::new("youtube", "feed", "test"),
+            title: "Test Video".to_string(),
+            content: ItemContent::Video {
+                description: "Test description".to_string(),
+                duration_seconds: Some(300),
+                view_count: Some(1000),
+            },
+            author: None,
+            published: None,
+            updated: None,
+            url: Some("https://www.youtube.com/watch?v=test".to_string()),
+            thumbnail_url: None,
+            is_read: false,
+            is_saved: false,
+            tags: vec![],
+            metadata: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_download_action_available() {
+        let provider = create_test_provider();
+        let item = create_test_video_item();
+        let actions = provider.available_actions(&item).await.unwrap();
+        assert!(actions.iter().any(|a| a.id == "download"));
+    }
 }


### PR DESCRIPTION
## Summary
Adds a reusable playlist picker modal widget for selecting playlists.

## Changes
- New PlaylistPicker widget with modal overlay
- PlaylistPickerState for navigation management
- Keyboard navigation: j/k to move, Enter to select, Esc to cancel
- Shows playlist names with item counts
- Includes 'Create New Playlist' option
- Centered modal with help text

## Usage
```rust
let picker = PlaylistPicker::new(&playlists, &state, &theme);
picker.render(frame, area);
```

Partially addresses #45