### PR TITLE
feat(provider-miniflux): Miniflux as HasFeeds + HasSavedItems provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "providers/provider-bookmarks",
     "providers/provider-email-imap",
     "providers/provider-reddit",
+    "providers/provider-miniflux",
     "providers/provider-rss",
     "providers/provider-youtube",
     "providers/provider-spotify",

--- a/providers/provider-miniflux/Cargo.toml
+++ b/providers/provider-miniflux/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "provider-miniflux"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Miniflux feed-reader provider for Scryforge"
+
+[dependencies]
+scryforge-provider-core.workspace = true
+async-trait.workspace = true
+chrono.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+thiserror.workspace = true
+
+# HTTP client with rustls-tls
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+
+# Optional Sigilforge integration for API tokens
+scryforge-sigilforge-client = { workspace = true, optional = true }
+
+[features]
+default = []
+sigilforge = ["scryforge-sigilforge-client", "scryforge-provider-core/sigilforge"]
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+wiremock = "0.6"
+serde_json = "1.0"

--- a/providers/provider-miniflux/README.md
+++ b/providers/provider-miniflux/README.md
@@ -1,0 +1,147 @@
+# provider-miniflux
+
+[Miniflux](https://miniflux.app) provider for Scryforge.
+
+`provider-miniflux` is the always-on, multi-device counterpart to
+[`provider-rss`](../provider-rss). Where `provider-rss` fetches and parses
+feeds itself, `provider-miniflux` delegates to a self-hosted Miniflux server's
+JSON API. Miniflux owns sync, caching, OPML import, and webhooks; Scryforge
+just becomes a terminal-native client over the user's existing subscriptions.
+
+## Capability matrix
+
+| Trait | Implemented | Notes |
+|-------|-------------|-------|
+| `Provider` | yes | `health_check` hits `GET /v1/me`; `sync` is a no-op probe via `GET /v1/feeds` since the server already syncs continuously |
+| `HasFeeds` | yes | `list_feeds` → `GET /v1/feeds`; `get_feed_items` → `GET /v1/entries?feed_id=...&status=...` |
+| `HasSavedItems` | yes | `get_saved_items` → `GET /v1/entries?starred=true`; `save_item` / `unsave_item` use `PUT /v1/entries/<id>/bookmark` |
+| `HasCollections` | no | Miniflux categories are not modelled as collections (yet) |
+| `HasCommunities` | no | |
+
+## Configuration
+
+```rust
+use provider_miniflux::{MinifluxProvider, MinifluxProviderConfig};
+
+let config = MinifluxProviderConfig::new(
+    "https://miniflux.example.com",
+    "your-api-token",
+);
+let provider = MinifluxProvider::new(config);
+```
+
+The API token is generated in the Miniflux UI under **Settings → API Keys**.
+It is sent on every request as the `X-Auth-Token` header.
+
+### Sigilforge integration
+
+If you store the token in [Sigilforge], enable the `sigilforge` cargo feature
+and construct the config with `from_sigilforge`:
+
+```toml
+[dependencies]
+provider-miniflux = { version = "0.1", features = ["sigilforge"] }
+```
+
+```rust,no_run
+# #[cfg(feature = "sigilforge")]
+# async fn example(fetcher: &dyn scryforge_sigilforge_client::TokenFetcher)
+#     -> Result<(), Box<dyn std::error::Error>>
+# {
+use provider_miniflux::{MinifluxProvider, MinifluxProviderConfig};
+
+let config = MinifluxProviderConfig::from_sigilforge(
+    fetcher,
+    "https://miniflux.example.com",
+    "personal", // account label registered with Sigilforge
+).await?;
+let provider = MinifluxProvider::new(config);
+# Ok(())
+# }
+```
+
+The token is looked up under service `"miniflux"` and the `account` label you
+pass.
+
+[Sigilforge]: https://github.com/raibid-labs/sigilforge
+
+## Item mapping
+
+Miniflux entries are mapped to Scryforge items as follows:
+
+| Miniflux Entry | Scryforge Item |
+|----------------|----------------|
+| `id` | `ItemId("miniflux:{id}")` |
+| `title` | `title` |
+| `url` | `url` |
+| `content` | `ItemContent::Article.full_content` |
+| `author` | `author.name` |
+| `published_at` | `published` |
+| `created_at` (fallback `changed_at`) | `updated` |
+| `feed.title` | `metadata["feed_title"]` |
+| `feed.category.title` | `metadata["feed_category"]` |
+| `tags` | `tags` |
+| First `image/*` enclosure (else first enclosure) | `thumbnail_url` |
+| `status == "read"` | `is_read` |
+| `starred` | `is_saved` |
+| `feed_id` | `metadata["miniflux_feed_id"]`, `stream_id = miniflux:feed:{feed_id}` |
+
+## Available actions
+
+- **Open in Browser** — opens `item.url`
+- **Preview** — TUI in-place preview
+- **Copy Link** — copy `item.url` to clipboard
+- **Mark as Read / Mark as Unread** — round-trips to `PUT /v1/entries`
+- **Star Article** — round-trips to `PUT /v1/entries/<id>/bookmark`
+
+`MarkRead`/`MarkUnread` and `Save`/`Unsave` mutate state on the Miniflux
+server, so they immediately propagate to every other Miniflux client.
+
+## Errors
+
+`MinifluxApiError` covers the HTTP-shaped failures and is converted into
+`StreamError` via `From`:
+
+| `MinifluxApiError` | `StreamError` |
+|--------------------|---------------|
+| `Http(_)` | `Network` |
+| `Unauthorized` / `Forbidden` | `AuthRequired` |
+| `NotFound` | `Provider` |
+| `RateLimited` | `RateLimited(60)` |
+| `Status { .. }` / `Json(_)` / `Config(_)` | `Provider` |
+
+## Testing
+
+```bash
+cargo test -p provider-miniflux
+```
+
+Integration tests in `tests/integration_test.rs` use [`wiremock`] to stand up
+an in-process HTTP server impersonating Miniflux, so no live server is
+required. They cover:
+
+- Listing feeds
+- Listing unread entries scoped to a feed
+- Listing starred entries via `HasSavedItems`
+- `save_item` is idempotent when the entry is already starred
+- `unsave_item` toggles only when currently starred
+- Mark-read action round-trips via `PUT /v1/entries`
+- Star action round-trips via `PUT /v1/entries/<id>/bookmark`
+- 401 responses surface as `StreamError::AuthRequired`
+- `health_check` uses `GET /v1/me`
+
+[`wiremock`]: https://crates.io/crates/wiremock
+
+## Dependencies
+
+- **reqwest** (0.12, `rustls-tls`, `json`) — HTTP client
+- **serde / serde_json** — JSON
+- **chrono** — timestamps
+- **async-trait** — async trait support
+- **thiserror** — error enums
+- **scryforge-sigilforge-client** (optional, behind `sigilforge` feature)
+- **wiremock** (dev-only) — mock Miniflux server for integration tests
+
+## License
+
+MIT OR Apache-2.0

--- a/providers/provider-miniflux/src/api.rs
+++ b/providers/provider-miniflux/src/api.rs
@@ -1,0 +1,392 @@
+//! Typed Miniflux JSON API client.
+//!
+//! This module is a thin wrapper around `reqwest` that exposes only the subset
+//! of the Miniflux API surface used by [`MinifluxProvider`](crate::MinifluxProvider).
+//!
+//! All requests authenticate via the `X-Auth-Token` header.
+
+use chrono::{DateTime, Utc};
+use reqwest::{Client, StatusCode};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+/// Errors raised by the Miniflux API client.
+#[derive(Debug, Error)]
+pub enum MinifluxApiError {
+    /// Underlying transport error (DNS, TLS, connection refused, decode, ...).
+    #[error("HTTP transport error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// 401 Unauthorized — usually a missing or revoked API token.
+    #[error("Unauthorized (check API token)")]
+    Unauthorized,
+
+    /// 403 Forbidden — token lacks permission for the requested resource.
+    #[error("Forbidden")]
+    Forbidden,
+
+    /// 404 Not Found — feed/entry id does not exist.
+    #[error("Not found")]
+    NotFound,
+
+    /// 429 Too Many Requests — Miniflux rate-limited us.
+    #[error("Rate limited")]
+    RateLimited,
+
+    /// Generic non-success response with the body text.
+    #[error("Miniflux API error ({status}): {body}")]
+    Status { status: u16, body: String },
+
+    /// JSON serialization/deserialization error.
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// Invalid configuration (bad URL etc.).
+    #[error("Invalid config: {0}")]
+    Config(String),
+}
+
+// ============================================================================
+// Response types (subset)
+// ============================================================================
+
+/// Logged-in user information returned by `GET /v1/me`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct User {
+    pub id: i64,
+    pub username: String,
+    #[serde(default)]
+    pub is_admin: bool,
+}
+
+/// Category metadata returned by `GET /v1/categories`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Category {
+    pub id: i64,
+    pub title: String,
+    #[serde(default)]
+    pub user_id: i64,
+}
+
+/// Subscribed feed returned by `GET /v1/feeds`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Feed {
+    pub id: i64,
+    #[serde(default)]
+    pub user_id: i64,
+    pub feed_url: String,
+    pub site_url: Option<String>,
+    pub title: String,
+    pub checked_at: Option<DateTime<Utc>>,
+    pub category: Option<Category>,
+    #[serde(default)]
+    pub icon: Option<FeedIcon>,
+}
+
+/// Lightweight feed-icon reference embedded in a feed payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeedIcon {
+    pub feed_id: i64,
+    pub icon_id: i64,
+}
+
+/// An enclosure attached to an entry (image/audio/video link).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Enclosure {
+    pub id: i64,
+    pub url: String,
+    #[serde(default)]
+    pub mime_type: String,
+    #[serde(default)]
+    pub size: i64,
+}
+
+/// Feed reference embedded in an `Entry`. Subset of the full `Feed` shape, kept
+/// permissive so we degrade gracefully if Miniflux adds fields.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntryFeed {
+    pub id: i64,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub site_url: Option<String>,
+    #[serde(default)]
+    pub feed_url: Option<String>,
+    #[serde(default)]
+    pub category: Option<Category>,
+}
+
+/// An article/entry. `status` is one of `"unread"`, `"read"`, or `"removed"`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Entry {
+    pub id: i64,
+    pub user_id: i64,
+    pub feed_id: i64,
+    pub status: String,
+    pub hash: String,
+    pub title: String,
+    pub url: String,
+    #[serde(default)]
+    pub comments_url: String,
+    pub published_at: Option<DateTime<Utc>>,
+    pub created_at: Option<DateTime<Utc>>,
+    pub changed_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub author: String,
+    #[serde(default)]
+    pub content: String,
+    #[serde(default)]
+    pub share_code: String,
+    #[serde(default)]
+    pub starred: bool,
+    #[serde(default)]
+    pub reading_time: i64,
+    #[serde(default)]
+    pub enclosures: Vec<Enclosure>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    pub feed: Option<EntryFeed>,
+}
+
+/// Paged entry collection returned by `GET /v1/entries`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntriesResponse {
+    pub total: i64,
+    #[serde(default)]
+    pub entries: Vec<Entry>,
+}
+
+/// Filter knobs for `GET /v1/entries`.
+#[derive(Debug, Clone, Default)]
+pub struct EntryFilter {
+    pub status: Option<String>,
+    pub feed_id: Option<i64>,
+    pub starred: Option<bool>,
+    pub limit: Option<u32>,
+    pub offset: Option<u32>,
+    pub order: Option<String>,
+    pub direction: Option<String>,
+    pub published_after: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+struct UpdateEntriesRequest<'a> {
+    entry_ids: &'a [i64],
+    status: &'a str,
+}
+
+// ============================================================================
+// Client
+// ============================================================================
+
+/// Minimal typed Miniflux API client.
+///
+/// Re-uses a single `reqwest::Client` across calls so connections are pooled.
+#[derive(Debug, Clone)]
+pub struct MinifluxClient {
+    base_url: String,
+    api_token: String,
+    http: Client,
+}
+
+impl MinifluxClient {
+    /// Build a new client. `base_url` must be the server root; trailing slashes
+    /// are normalised away.
+    pub fn new(base_url: impl Into<String>, api_token: impl Into<String>) -> Self {
+        let base = base_url.into().trim_end_matches('/').to_string();
+        let http = Client::builder()
+            .user_agent("scryforge-provider-miniflux/0.1.0")
+            .build()
+            .unwrap_or_default();
+        Self {
+            base_url: base,
+            api_token: api_token.into(),
+            http,
+        }
+    }
+
+    /// Build a new client with an explicit `reqwest::Client` (mainly for tests).
+    pub fn with_http(
+        base_url: impl Into<String>,
+        api_token: impl Into<String>,
+        http: Client,
+    ) -> Self {
+        let base = base_url.into().trim_end_matches('/').to_string();
+        Self {
+            base_url: base,
+            api_token: api_token.into(),
+            http,
+        }
+    }
+
+    /// Server base URL (without trailing slash).
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.base_url, path)
+    }
+
+    async fn check_status(
+        response: reqwest::Response,
+    ) -> std::result::Result<reqwest::Response, MinifluxApiError> {
+        let status = response.status();
+        if status.is_success() {
+            return Ok(response);
+        }
+        match status {
+            StatusCode::UNAUTHORIZED => Err(MinifluxApiError::Unauthorized),
+            StatusCode::FORBIDDEN => Err(MinifluxApiError::Forbidden),
+            StatusCode::NOT_FOUND => Err(MinifluxApiError::NotFound),
+            StatusCode::TOO_MANY_REQUESTS => Err(MinifluxApiError::RateLimited),
+            other => {
+                let body = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "<unreadable body>".to_string());
+                Err(MinifluxApiError::Status {
+                    status: other.as_u16(),
+                    body,
+                })
+            }
+        }
+    }
+
+    async fn get_json<T>(&self, path: &str) -> std::result::Result<T, MinifluxApiError>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        let response = self
+            .http
+            .get(self.url(path))
+            .header("X-Auth-Token", &self.api_token)
+            .send()
+            .await?;
+        let response = Self::check_status(response).await?;
+        Ok(response.json::<T>().await?)
+    }
+
+    /// `GET /v1/me` — return information about the authenticated user.
+    pub async fn me(&self) -> std::result::Result<User, MinifluxApiError> {
+        self.get_json("/v1/me").await
+    }
+
+    /// `GET /v1/feeds` — list every feed the authenticated user subscribes to.
+    pub async fn list_feeds(&self) -> std::result::Result<Vec<Feed>, MinifluxApiError> {
+        self.get_json("/v1/feeds").await
+    }
+
+    /// `GET /v1/categories` — list user-defined categories.
+    pub async fn list_categories(&self) -> std::result::Result<Vec<Category>, MinifluxApiError> {
+        self.get_json("/v1/categories").await
+    }
+
+    /// `GET /v1/entries` with the given filters.
+    pub async fn list_entries(
+        &self,
+        filter: &EntryFilter,
+    ) -> std::result::Result<EntriesResponse, MinifluxApiError> {
+        let mut query: Vec<(&str, String)> = Vec::new();
+        if let Some(status) = &filter.status {
+            query.push(("status", status.clone()));
+        }
+        if let Some(feed_id) = filter.feed_id {
+            query.push(("feed_id", feed_id.to_string()));
+        }
+        if let Some(starred) = filter.starred {
+            query.push(("starred", starred.to_string()));
+        }
+        if let Some(limit) = filter.limit {
+            query.push(("limit", limit.to_string()));
+        }
+        if let Some(offset) = filter.offset {
+            query.push(("offset", offset.to_string()));
+        }
+        if let Some(order) = &filter.order {
+            query.push(("order", order.clone()));
+        }
+        if let Some(direction) = &filter.direction {
+            query.push(("direction", direction.clone()));
+        }
+        if let Some(after) = filter.published_after {
+            query.push(("published_after", after.to_string()));
+        }
+
+        let response = self
+            .http
+            .get(self.url("/v1/entries"))
+            .header("X-Auth-Token", &self.api_token)
+            .query(&query)
+            .send()
+            .await?;
+        let response = Self::check_status(response).await?;
+        Ok(response.json::<EntriesResponse>().await?)
+    }
+
+    /// `PUT /v1/entries` — bulk-update entry status (`"read"`, `"unread"`, or
+    /// `"removed"`).
+    pub async fn update_entries_status(
+        &self,
+        entry_ids: &[i64],
+        status: &str,
+    ) -> std::result::Result<(), MinifluxApiError> {
+        let body = UpdateEntriesRequest { entry_ids, status };
+        let response = self
+            .http
+            .put(self.url("/v1/entries"))
+            .header("X-Auth-Token", &self.api_token)
+            .json(&body)
+            .send()
+            .await?;
+        Self::check_status(response).await?;
+        Ok(())
+    }
+
+    /// `PUT /v1/entries/<id>/bookmark` — toggle the entry's `starred` state.
+    pub async fn toggle_bookmark(
+        &self,
+        entry_id: i64,
+    ) -> std::result::Result<(), MinifluxApiError> {
+        let response = self
+            .http
+            .put(self.url(&format!("/v1/entries/{}/bookmark", entry_id)))
+            .header("X-Auth-Token", &self.api_token)
+            .send()
+            .await?;
+        Self::check_status(response).await?;
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Error mapping
+// ============================================================================
+
+impl From<MinifluxApiError> for scryforge_provider_core::StreamError {
+    fn from(err: MinifluxApiError) -> Self {
+        use scryforge_provider_core::StreamError;
+        match err {
+            MinifluxApiError::Http(e) => StreamError::Network(e.to_string()),
+            MinifluxApiError::Unauthorized => {
+                StreamError::AuthRequired("Miniflux API token missing or invalid".to_string())
+            }
+            MinifluxApiError::Forbidden => {
+                StreamError::AuthRequired("Miniflux API token forbidden".to_string())
+            }
+            MinifluxApiError::NotFound => StreamError::Provider("Miniflux: not found".to_string()),
+            MinifluxApiError::RateLimited => StreamError::RateLimited(60),
+            MinifluxApiError::Status { status, body } => {
+                StreamError::Provider(format!("Miniflux HTTP {status}: {body}"))
+            }
+            MinifluxApiError::Json(e) => {
+                StreamError::Provider(format!("Miniflux JSON decode failed: {e}"))
+            }
+            MinifluxApiError::Config(e) => StreamError::Provider(format!("Miniflux config: {e}")),
+        }
+    }
+}

--- a/providers/provider-miniflux/src/config.rs
+++ b/providers/provider-miniflux/src/config.rs
@@ -1,0 +1,41 @@
+//! Configuration for the Miniflux provider.
+
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the [`MinifluxProvider`](crate::MinifluxProvider).
+///
+/// `server_url` should point at the root of the Miniflux server (e.g.
+/// `https://miniflux.example.com`). The `api_token` is a per-user token
+/// generated in the Miniflux UI under Settings → API Keys and is sent to the
+/// server in the `X-Auth-Token` header.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MinifluxProviderConfig {
+    /// Base URL of the Miniflux server, e.g. `https://miniflux.example.com`.
+    pub server_url: String,
+    /// API token used for `X-Auth-Token` authentication.
+    pub api_token: String,
+}
+
+impl MinifluxProviderConfig {
+    /// Create a new configuration from a server URL and API token.
+    pub fn new(server_url: impl Into<String>, api_token: impl Into<String>) -> Self {
+        Self {
+            server_url: server_url.into(),
+            api_token: api_token.into(),
+        }
+    }
+
+    /// Construct a configuration by fetching the API token from Sigilforge.
+    ///
+    /// Looks up the token under the service identifier `"miniflux"` and the
+    /// supplied `account` label.
+    #[cfg(feature = "sigilforge")]
+    pub async fn from_sigilforge(
+        token_fetcher: &dyn scryforge_sigilforge_client::TokenFetcher,
+        server_url: impl Into<String>,
+        account: &str,
+    ) -> std::result::Result<Self, scryforge_sigilforge_client::SigilforgeError> {
+        let token = token_fetcher.fetch_token("miniflux", account).await?;
+        Ok(Self::new(server_url, token))
+    }
+}

--- a/providers/provider-miniflux/src/lib.rs
+++ b/providers/provider-miniflux/src/lib.rs
@@ -1,0 +1,473 @@
+//! # provider-miniflux
+//!
+//! [Miniflux](https://miniflux.app) provider for Scryforge.
+//!
+//! This crate implements [`Provider`], [`HasFeeds`], and [`HasSavedItems`] by
+//! delegating to a self-hosted Miniflux server's JSON API. It is the
+//! always-on, multi-device counterpart to [`provider-rss`](../provider-rss):
+//! Miniflux owns "fetch and cache feeds" while Scryforge becomes a
+//! terminal-native client over the user's existing subscriptions.
+//!
+//! ## Configuration
+//!
+//! ```no_run
+//! use provider_miniflux::{MinifluxProvider, MinifluxProviderConfig};
+//!
+//! let config = MinifluxProviderConfig::new(
+//!     "https://miniflux.example.com",
+//!     "your-api-token",
+//! );
+//! let provider = MinifluxProvider::new(config);
+//! ```
+//!
+//! ## Sigilforge integration (optional)
+//!
+//! Enable the `sigilforge` cargo feature to fetch the API token from a
+//! [Sigilforge] daemon instead of passing it inline:
+//!
+//! ```toml
+//! [dependencies]
+//! provider-miniflux = { version = "0.1", features = ["sigilforge"] }
+//! ```
+//!
+//! ```no_run
+//! # #[cfg(feature = "sigilforge")]
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! use provider_miniflux::{MinifluxProvider, MinifluxProviderConfig};
+//! use scryforge_sigilforge_client::MockTokenFetcher;
+//!
+//! let fetcher = MockTokenFetcher::empty();
+//! let config = MinifluxProviderConfig::from_sigilforge(
+//!     &fetcher,
+//!     "https://miniflux.example.com",
+//!     "personal",
+//! ).await?;
+//! let provider = MinifluxProvider::new(config);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [Sigilforge]: https://github.com/raibid-labs/sigilforge
+
+pub mod api;
+pub mod config;
+pub mod mapping;
+
+pub use config::MinifluxProviderConfig;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use scryforge_provider_core::prelude::*;
+use std::any::Any;
+use std::time::Instant;
+
+use crate::api::EntryFilter;
+use crate::mapping::{
+    entry_to_item, feed_to_feed, parse_feed_id, parse_item_id, saved_stream_id, PROVIDER_ID,
+};
+
+pub use crate::api::{MinifluxApiError, MinifluxClient};
+
+/// Miniflux provider implementing `Provider + HasFeeds + HasSavedItems`.
+pub struct MinifluxProvider {
+    client: MinifluxClient,
+}
+
+impl MinifluxProvider {
+    /// Create a new provider from a [`MinifluxProviderConfig`].
+    pub fn new(config: MinifluxProviderConfig) -> Self {
+        let client = MinifluxClient::new(config.server_url, config.api_token);
+        Self { client }
+    }
+
+    /// Create a new provider from a pre-constructed [`MinifluxClient`].
+    /// Useful for tests that want to inject a custom `reqwest::Client`.
+    pub fn with_client(client: MinifluxClient) -> Self {
+        Self { client }
+    }
+
+    /// Borrow the underlying API client (mainly for tests).
+    pub fn client(&self) -> &MinifluxClient {
+        &self.client
+    }
+}
+
+#[async_trait]
+impl Provider for MinifluxProvider {
+    fn id(&self) -> &'static str {
+        PROVIDER_ID
+    }
+
+    fn name(&self) -> &'static str {
+        "Miniflux"
+    }
+
+    async fn health_check(&self) -> Result<ProviderHealth> {
+        match self.client.me().await {
+            Ok(user) => Ok(ProviderHealth {
+                is_healthy: true,
+                message: Some(format!("Connected to Miniflux as {}", user.username)),
+                last_sync: Some(Utc::now()),
+                error_count: 0,
+            }),
+            Err(e) => Ok(ProviderHealth {
+                is_healthy: false,
+                message: Some(format!("Miniflux health check failed: {e}")),
+                last_sync: None,
+                error_count: 1,
+            }),
+        }
+    }
+
+    async fn sync(&self) -> Result<SyncResult> {
+        let start = Instant::now();
+        // Miniflux owns sync server-side; we just count how many feeds exist as
+        // a sanity probe.
+        match self.client.list_feeds().await {
+            Ok(feeds) => Ok(SyncResult {
+                success: true,
+                items_added: feeds.len() as u32,
+                items_updated: 0,
+                items_removed: 0,
+                errors: Vec::new(),
+                duration_ms: start.elapsed().as_millis() as u64,
+            }),
+            Err(e) => Ok(SyncResult {
+                success: false,
+                items_added: 0,
+                items_updated: 0,
+                items_removed: 0,
+                errors: vec![e.to_string()],
+                duration_ms: start.elapsed().as_millis() as u64,
+            }),
+        }
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            has_feeds: true,
+            has_collections: false,
+            has_saved_items: true,
+            has_communities: false,
+        }
+    }
+
+    async fn available_actions(&self, _item: &Item) -> Result<Vec<Action>> {
+        Ok(vec![
+            Action {
+                id: "open_browser".to_string(),
+                name: "Open in Browser".to_string(),
+                description: "Open the article URL in the default browser".to_string(),
+                kind: ActionKind::OpenInBrowser,
+                keyboard_shortcut: Some("o".to_string()),
+            },
+            Action {
+                id: "preview".to_string(),
+                name: "Preview".to_string(),
+                description: "Show article preview".to_string(),
+                kind: ActionKind::Preview,
+                keyboard_shortcut: Some("p".to_string()),
+            },
+            Action {
+                id: "copy_link".to_string(),
+                name: "Copy Link".to_string(),
+                description: "Copy the article URL to the clipboard".to_string(),
+                kind: ActionKind::CopyLink,
+                keyboard_shortcut: Some("c".to_string()),
+            },
+            Action {
+                id: "mark_read".to_string(),
+                name: "Mark as Read".to_string(),
+                description: "Mark the article as read on the Miniflux server".to_string(),
+                kind: ActionKind::MarkRead,
+                keyboard_shortcut: Some("r".to_string()),
+            },
+            Action {
+                id: "mark_unread".to_string(),
+                name: "Mark as Unread".to_string(),
+                description: "Mark the article as unread on the Miniflux server".to_string(),
+                kind: ActionKind::MarkUnread,
+                keyboard_shortcut: Some("u".to_string()),
+            },
+            Action {
+                id: "save".to_string(),
+                name: "Star Article".to_string(),
+                description: "Toggle the bookmark/star flag on the Miniflux server".to_string(),
+                kind: ActionKind::Save,
+                keyboard_shortcut: Some("s".to_string()),
+            },
+        ])
+    }
+
+    async fn execute_action(&self, item: &Item, action: &Action) -> Result<ActionResult> {
+        match action.kind {
+            ActionKind::OpenInBrowser => Ok(match &item.url {
+                Some(url) => ActionResult {
+                    success: true,
+                    message: Some(format!("Opening {url}")),
+                    data: Some(serde_json::json!({ "url": url })),
+                },
+                None => ActionResult {
+                    success: false,
+                    message: Some("Item has no URL".to_string()),
+                    data: None,
+                },
+            }),
+            ActionKind::CopyLink => Ok(match &item.url {
+                Some(url) => ActionResult {
+                    success: true,
+                    message: Some("Copied link to clipboard".to_string()),
+                    data: Some(serde_json::json!({ "url": url })),
+                },
+                None => ActionResult {
+                    success: false,
+                    message: Some("Item has no URL".to_string()),
+                    data: None,
+                },
+            }),
+            ActionKind::MarkRead | ActionKind::MarkUnread => {
+                let entry_id = parse_item_id(&item.id).ok_or_else(|| {
+                    StreamError::ItemNotFound(format!(
+                        "item id is not a Miniflux entry id: {}",
+                        item.id.as_str()
+                    ))
+                })?;
+                let target = if action.kind == ActionKind::MarkRead {
+                    "read"
+                } else {
+                    "unread"
+                };
+                self.client
+                    .update_entries_status(&[entry_id], target)
+                    .await?;
+                Ok(ActionResult {
+                    success: true,
+                    message: Some(format!("Marked entry {entry_id} as {target}")),
+                    data: Some(serde_json::json!({
+                        "entry_id": entry_id,
+                        "status": target,
+                    })),
+                })
+            }
+            ActionKind::Save | ActionKind::Unsave => {
+                let entry_id = parse_item_id(&item.id).ok_or_else(|| {
+                    StreamError::ItemNotFound(format!(
+                        "item id is not a Miniflux entry id: {}",
+                        item.id.as_str()
+                    ))
+                })?;
+                self.client.toggle_bookmark(entry_id).await?;
+                Ok(ActionResult {
+                    success: true,
+                    message: Some(format!("Toggled bookmark on entry {entry_id}")),
+                    data: Some(serde_json::json!({ "entry_id": entry_id })),
+                })
+            }
+            _ => Ok(ActionResult {
+                success: true,
+                message: Some(format!("Executed action: {}", action.name)),
+                data: None,
+            }),
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[async_trait]
+impl HasFeeds for MinifluxProvider {
+    async fn list_feeds(&self) -> Result<Vec<Feed>> {
+        let feeds = self.client.list_feeds().await?;
+        Ok(feeds.iter().map(feed_to_feed).collect())
+    }
+
+    async fn get_feed_items(&self, feed_id: &FeedId, options: FeedOptions) -> Result<Vec<Item>> {
+        let numeric =
+            parse_feed_id(feed_id).ok_or_else(|| StreamError::StreamNotFound(feed_id.0.clone()))?;
+
+        let mut filter = EntryFilter {
+            feed_id: Some(numeric),
+            limit: options.limit,
+            offset: options.offset,
+            order: Some("published_at".to_string()),
+            direction: Some("desc".to_string()),
+            ..Default::default()
+        };
+        if !options.include_read {
+            filter.status = Some("unread".to_string());
+        }
+        if let Some(since) = options.since {
+            filter.published_after = Some(since.timestamp());
+        }
+
+        let response = self.client.list_entries(&filter).await?;
+        let stream_id = mapping::feed_stream_id(numeric);
+        let items = response
+            .entries
+            .into_iter()
+            .map(|entry| entry_to_item(&entry, stream_id.clone()))
+            .collect();
+        Ok(items)
+    }
+}
+
+#[async_trait]
+impl HasSavedItems for MinifluxProvider {
+    async fn get_saved_items(&self, options: SavedItemsOptions) -> Result<Vec<Item>> {
+        let filter = EntryFilter {
+            starred: Some(true),
+            limit: options.limit,
+            offset: options.offset,
+            order: Some("changed_at".to_string()),
+            direction: Some("desc".to_string()),
+            ..Default::default()
+        };
+        let response = self.client.list_entries(&filter).await?;
+        let stream_id = saved_stream_id();
+        let items = response
+            .entries
+            .into_iter()
+            .map(|entry| entry_to_item(&entry, stream_id.clone()))
+            .collect();
+        Ok(items)
+    }
+
+    async fn is_saved(&self, item_id: &ItemId) -> Result<bool> {
+        let entry_id =
+            parse_item_id(item_id).ok_or_else(|| StreamError::ItemNotFound(item_id.0.clone()))?;
+
+        // The simplest reliable signal: list starred entries and check whether
+        // this id is present. Miniflux exposes a single-entry GET as well, but
+        // staying on the listing endpoint keeps the API surface narrow and the
+        // wiremock test surface small.
+        let filter = EntryFilter {
+            starred: Some(true),
+            limit: Some(500),
+            ..Default::default()
+        };
+        let response = self.client.list_entries(&filter).await?;
+        Ok(response.entries.iter().any(|e| e.id == entry_id))
+    }
+
+    async fn save_item(&self, item_id: &ItemId) -> Result<()> {
+        let entry_id =
+            parse_item_id(item_id).ok_or_else(|| StreamError::ItemNotFound(item_id.0.clone()))?;
+        // `PUT /v1/entries/<id>/bookmark` toggles. To make `save_item` an
+        // idempotent "ensure starred", first check current state.
+        if !self.is_saved(item_id).await? {
+            self.client.toggle_bookmark(entry_id).await?;
+        }
+        Ok(())
+    }
+
+    async fn unsave_item(&self, item_id: &ItemId) -> Result<()> {
+        let entry_id =
+            parse_item_id(item_id).ok_or_else(|| StreamError::ItemNotFound(item_id.0.clone()))?;
+        if self.is_saved(item_id).await? {
+            self.client.toggle_bookmark(entry_id).await?;
+        }
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Tests (unit only — wiremock-driven integration tests live in tests/)
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider() -> MinifluxProvider {
+        MinifluxProvider::new(MinifluxProviderConfig::new(
+            "http://localhost:0",
+            "test-token",
+        ))
+    }
+
+    #[tokio::test]
+    async fn provider_basics() {
+        let p = provider();
+        assert_eq!(p.id(), "miniflux");
+        assert_eq!(p.name(), "Miniflux");
+        let caps = p.capabilities();
+        assert!(caps.has_feeds);
+        assert!(caps.has_saved_items);
+        assert!(!caps.has_collections);
+        assert!(!caps.has_communities);
+    }
+
+    #[tokio::test]
+    async fn open_browser_action_uses_url() {
+        let p = provider();
+        let item = Item {
+            id: ItemId::new(PROVIDER_ID, "1"),
+            stream_id: mapping::feed_stream_id(1),
+            title: "x".to_string(),
+            content: ItemContent::Article {
+                summary: None,
+                full_content: None,
+            },
+            author: None,
+            published: None,
+            updated: None,
+            url: Some("https://example.com".to_string()),
+            thumbnail_url: None,
+            is_read: false,
+            is_saved: false,
+            tags: vec![],
+            metadata: Default::default(),
+        };
+        let action = Action {
+            id: "open_browser".to_string(),
+            name: "Open in Browser".to_string(),
+            description: String::new(),
+            kind: ActionKind::OpenInBrowser,
+            keyboard_shortcut: None,
+        };
+        let result = p.execute_action(&item, &action).await.unwrap();
+        assert!(result.success);
+    }
+
+    #[tokio::test]
+    async fn open_browser_action_without_url_fails() {
+        let p = provider();
+        let item = Item {
+            id: ItemId::new(PROVIDER_ID, "1"),
+            stream_id: mapping::feed_stream_id(1),
+            title: "x".to_string(),
+            content: ItemContent::Article {
+                summary: None,
+                full_content: None,
+            },
+            author: None,
+            published: None,
+            updated: None,
+            url: None,
+            thumbnail_url: None,
+            is_read: false,
+            is_saved: false,
+            tags: vec![],
+            metadata: Default::default(),
+        };
+        let action = Action {
+            id: "open_browser".to_string(),
+            name: "Open in Browser".to_string(),
+            description: String::new(),
+            kind: ActionKind::OpenInBrowser,
+            keyboard_shortcut: None,
+        };
+        let result = p.execute_action(&item, &action).await.unwrap();
+        assert!(!result.success);
+    }
+
+    #[test]
+    fn build_feed_id_format() {
+        // Round-tripping a Miniflux feed id through `feed_stream_id` and the
+        // exposed feed-id format keeps the encoding consistent.
+        let stream = mapping::feed_stream_id(99);
+        assert_eq!(stream.as_str(), "miniflux:feed:99");
+    }
+}

--- a/providers/provider-miniflux/src/mapping.rs
+++ b/providers/provider-miniflux/src/mapping.rs
@@ -1,0 +1,237 @@
+//! Conversion between Miniflux API types and Scryforge domain types.
+
+use scryforge_provider_core::prelude::*;
+use std::collections::HashMap;
+
+use crate::api;
+
+/// Provider id used as the namespace prefix for `ItemId` / `StreamId`.
+pub(crate) const PROVIDER_ID: &str = "miniflux";
+
+/// Build a stream id of the form `miniflux:feed:<feed-id>`.
+pub(crate) fn feed_stream_id(feed_id: i64) -> StreamId {
+    StreamId::new(PROVIDER_ID, "feed", &feed_id.to_string())
+}
+
+/// Build the saved-items stream id used for starred entries.
+pub(crate) fn saved_stream_id() -> StreamId {
+    StreamId::new(PROVIDER_ID, "saved", "starred")
+}
+
+/// Build the public `FeedId` for a Miniflux feed.
+pub(crate) fn feed_id(feed_id: i64) -> FeedId {
+    FeedId(format!("miniflux:{}", feed_id))
+}
+
+/// Decode a `FeedId` produced by [`feed_id`] back into the numeric Miniflux id.
+pub(crate) fn parse_feed_id(id: &FeedId) -> Option<i64> {
+    id.0.strip_prefix("miniflux:")
+        .and_then(|s| s.parse::<i64>().ok())
+}
+
+/// Decode a `miniflux:<n>` `ItemId` back into the numeric Miniflux entry id.
+pub(crate) fn parse_item_id(id: &ItemId) -> Option<i64> {
+    id.0.strip_prefix("miniflux:")
+        .and_then(|s| s.parse::<i64>().ok())
+}
+
+/// Convert a Miniflux [`api::Feed`] into a Scryforge [`Feed`].
+pub fn feed_to_feed(feed: &api::Feed) -> Feed {
+    let description = feed
+        .category
+        .as_ref()
+        .map(|c| format!("Category: {}", c.title));
+    Feed {
+        id: feed_id(feed.id),
+        name: if feed.title.is_empty() {
+            feed.feed_url.clone()
+        } else {
+            feed.title.clone()
+        },
+        description,
+        icon: Some("📰".to_string()),
+        unread_count: None,
+        total_count: None,
+    }
+}
+
+/// Convert a Miniflux [`api::Entry`] into a Scryforge [`Item`].
+///
+/// `stream_id` controls which stream the resulting item is filed under (a feed
+/// stream when listing feeds, the starred-items stream when listing saved
+/// items, etc.).
+pub fn entry_to_item(entry: &api::Entry, stream_id: StreamId) -> Item {
+    let id = ItemId::new(PROVIDER_ID, &entry.id.to_string());
+
+    let title = if entry.title.is_empty() {
+        "(untitled)".to_string()
+    } else {
+        entry.title.clone()
+    };
+
+    let author = if entry.author.is_empty() {
+        None
+    } else {
+        Some(Author {
+            name: entry.author.clone(),
+            email: None,
+            url: None,
+            avatar_url: None,
+        })
+    };
+
+    let content = ItemContent::Article {
+        summary: None,
+        full_content: if entry.content.is_empty() {
+            None
+        } else {
+            Some(entry.content.clone())
+        },
+    };
+
+    // Best-effort thumbnail: first image-typed enclosure.
+    let thumbnail_url = entry
+        .enclosures
+        .iter()
+        .find(|enc| enc.mime_type.starts_with("image/"))
+        .or_else(|| entry.enclosures.first())
+        .map(|enc| enc.url.clone());
+
+    let url = if entry.url.is_empty() {
+        None
+    } else {
+        Some(entry.url.clone())
+    };
+
+    let mut metadata = HashMap::new();
+    metadata.insert("miniflux_feed_id".to_string(), entry.feed_id.to_string());
+    metadata.insert("miniflux_status".to_string(), entry.status.clone());
+    if !entry.hash.is_empty() {
+        metadata.insert("miniflux_hash".to_string(), entry.hash.clone());
+    }
+    if let Some(feed) = &entry.feed {
+        if !feed.title.is_empty() {
+            metadata.insert("feed_title".to_string(), feed.title.clone());
+        }
+        if let Some(category) = &feed.category {
+            metadata.insert("feed_category".to_string(), category.title.clone());
+        }
+    }
+
+    let is_read = entry.status == "read";
+    let tags = entry.tags.clone();
+
+    Item {
+        id,
+        stream_id,
+        title,
+        content,
+        author,
+        published: entry.published_at,
+        // The issue spec maps `created_at` → `updated` as a best-effort field;
+        // fall back to `changed_at` when `created_at` is missing.
+        updated: entry.created_at.or(entry.changed_at),
+        url,
+        thumbnail_url,
+        is_read,
+        is_saved: entry.starred,
+        tags,
+        metadata,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_entry() -> api::Entry {
+        api::Entry {
+            id: 42,
+            user_id: 1,
+            feed_id: 7,
+            status: "unread".to_string(),
+            hash: "abc123".to_string(),
+            title: "Hello, world".to_string(),
+            url: "https://example.com/post".to_string(),
+            comments_url: String::new(),
+            published_at: None,
+            created_at: None,
+            changed_at: None,
+            author: "Jane".to_string(),
+            content: "<p>Body</p>".to_string(),
+            share_code: String::new(),
+            starred: true,
+            reading_time: 0,
+            enclosures: vec![api::Enclosure {
+                id: 1,
+                url: "https://example.com/img.png".to_string(),
+                mime_type: "image/png".to_string(),
+                size: 0,
+            }],
+            tags: vec!["rust".to_string()],
+            feed: Some(api::EntryFeed {
+                id: 7,
+                title: "Sample Feed".to_string(),
+                site_url: Some("https://example.com".to_string()),
+                feed_url: Some("https://example.com/feed".to_string()),
+                category: Some(api::Category {
+                    id: 3,
+                    title: "Tech".to_string(),
+                    user_id: 1,
+                }),
+            }),
+        }
+    }
+
+    #[test]
+    fn entry_maps_to_item_with_expected_fields() {
+        let entry = sample_entry();
+        let item = entry_to_item(&entry, feed_stream_id(entry.feed_id));
+
+        assert_eq!(item.id.as_str(), "miniflux:42");
+        assert_eq!(item.stream_id.as_str(), "miniflux:feed:7");
+        assert_eq!(item.title, "Hello, world");
+        assert_eq!(item.url.as_deref(), Some("https://example.com/post"));
+        assert!(matches!(item.content, ItemContent::Article { .. }));
+        assert_eq!(
+            item.thumbnail_url.as_deref(),
+            Some("https://example.com/img.png")
+        );
+        assert!(!item.is_read);
+        assert!(item.is_saved);
+        assert_eq!(item.tags, vec!["rust".to_string()]);
+        assert_eq!(item.author.as_ref().unwrap().name, "Jane");
+        assert_eq!(
+            item.metadata.get("miniflux_feed_id").map(|s| s.as_str()),
+            Some("7")
+        );
+        assert_eq!(
+            item.metadata.get("feed_title").map(|s| s.as_str()),
+            Some("Sample Feed")
+        );
+        assert_eq!(
+            item.metadata.get("feed_category").map(|s| s.as_str()),
+            Some("Tech")
+        );
+    }
+
+    #[test]
+    fn read_status_propagates_to_item_flag() {
+        let mut entry = sample_entry();
+        entry.status = "read".to_string();
+        let item = entry_to_item(&entry, feed_stream_id(entry.feed_id));
+        assert!(item.is_read);
+    }
+
+    #[test]
+    fn feed_id_round_trips() {
+        let id = feed_id(123);
+        assert_eq!(parse_feed_id(&id), Some(123));
+    }
+
+    #[test]
+    fn item_id_round_trips() {
+        let id = ItemId::new(PROVIDER_ID, "987");
+        assert_eq!(parse_item_id(&id), Some(987));
+    }
+}

--- a/providers/provider-miniflux/tests/integration_test.rs
+++ b/providers/provider-miniflux/tests/integration_test.rs
@@ -1,0 +1,401 @@
+//! Wiremock-driven integration tests for `provider-miniflux`.
+//!
+//! These tests stand up a `wiremock::MockServer` to impersonate a Miniflux
+//! API and exercise the trait surface end-to-end against canned responses.
+
+use provider_miniflux::{MinifluxProvider, MinifluxProviderConfig};
+use scryforge_provider_core::prelude::*;
+use serde_json::json;
+use wiremock::matchers::{body_partial_json, header, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn provider_for(server: &MockServer) -> MinifluxProvider {
+    MinifluxProvider::new(MinifluxProviderConfig::new(server.uri(), "test-token"))
+}
+
+#[tokio::test]
+async fn list_feeds_round_trips() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/feeds"))
+        .and(header("X-Auth-Token", "test-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {
+                "id": 1,
+                "user_id": 1,
+                "feed_url": "https://example.com/feed.xml",
+                "site_url": "https://example.com",
+                "title": "Example Feed",
+                "checked_at": "2024-01-01T00:00:00Z",
+                "category": {"id": 1, "title": "News", "user_id": 1}
+            },
+            {
+                "id": 2,
+                "user_id": 1,
+                "feed_url": "https://blog.example.com/atom.xml",
+                "site_url": "https://blog.example.com",
+                "title": "Blog Feed",
+                "checked_at": null,
+                "category": null
+            }
+        ])))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = provider_for(&server);
+    let feeds = provider.list_feeds().await.unwrap();
+    assert_eq!(feeds.len(), 2);
+    assert_eq!(feeds[0].id.0, "miniflux:1");
+    assert_eq!(feeds[0].name, "Example Feed");
+    assert_eq!(feeds[0].description.as_deref(), Some("Category: News"));
+    assert_eq!(feeds[1].id.0, "miniflux:2");
+}
+
+#[tokio::test]
+async fn get_feed_items_filters_unread_by_default() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/entries"))
+        .and(query_param("feed_id", "7"))
+        .and(query_param("status", "unread"))
+        .and(header("X-Auth-Token", "test-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "total": 1,
+            "entries": [
+                {
+                    "id": 100,
+                    "user_id": 1,
+                    "feed_id": 7,
+                    "status": "unread",
+                    "hash": "deadbeef",
+                    "title": "Hello",
+                    "url": "https://example.com/hello",
+                    "comments_url": "",
+                    "published_at": "2024-01-01T12:00:00Z",
+                    "created_at": "2024-01-01T12:00:01Z",
+                    "changed_at": "2024-01-01T12:00:02Z",
+                    "author": "Author Name",
+                    "content": "<p>Body</p>",
+                    "share_code": "",
+                    "starred": false,
+                    "reading_time": 2,
+                    "enclosures": [],
+                    "tags": ["rust"],
+                    "feed": {
+                        "id": 7,
+                        "title": "Sample Feed",
+                        "site_url": "https://example.com",
+                        "feed_url": "https://example.com/feed",
+                        "category": {"id": 1, "title": "Tech", "user_id": 1}
+                    }
+                }
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = provider_for(&server);
+    let items = provider
+        .get_feed_items(&FeedId("miniflux:7".to_string()), FeedOptions::default())
+        .await
+        .unwrap();
+
+    assert_eq!(items.len(), 1);
+    let item = &items[0];
+    assert_eq!(item.id.as_str(), "miniflux:100");
+    assert_eq!(item.stream_id.as_str(), "miniflux:feed:7");
+    assert_eq!(item.title, "Hello");
+    assert_eq!(item.url.as_deref(), Some("https://example.com/hello"));
+    assert!(!item.is_read);
+    assert_eq!(item.tags, vec!["rust".to_string()]);
+    assert!(matches!(item.content, ItemContent::Article { .. }));
+}
+
+#[tokio::test]
+async fn get_feed_items_unknown_feed_id_is_stream_not_found() {
+    let server = MockServer::start().await;
+    let provider = provider_for(&server);
+    let err = provider
+        .get_feed_items(
+            &FeedId("not-miniflux:7".to_string()),
+            FeedOptions::default(),
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, StreamError::StreamNotFound(_)));
+}
+
+#[tokio::test]
+async fn get_saved_items_lists_starred_entries() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/entries"))
+        .and(query_param("starred", "true"))
+        .and(header("X-Auth-Token", "test-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "total": 1,
+            "entries": [
+                {
+                    "id": 200,
+                    "user_id": 1,
+                    "feed_id": 9,
+                    "status": "read",
+                    "hash": "hashy",
+                    "title": "Saved One",
+                    "url": "https://example.com/saved",
+                    "comments_url": "",
+                    "published_at": null,
+                    "created_at": null,
+                    "changed_at": null,
+                    "author": "",
+                    "content": "",
+                    "share_code": "",
+                    "starred": true,
+                    "reading_time": 0,
+                    "enclosures": [],
+                    "tags": [],
+                    "feed": null
+                }
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = provider_for(&server);
+    let items = provider
+        .get_saved_items(SavedItemsOptions::default())
+        .await
+        .unwrap();
+    assert_eq!(items.len(), 1);
+    assert!(items[0].is_saved);
+    assert_eq!(items[0].stream_id.as_str(), "miniflux:saved:starred");
+}
+
+#[tokio::test]
+async fn mark_read_action_round_trips_to_server() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/v1/entries"))
+        .and(header("X-Auth-Token", "test-token"))
+        .and(body_partial_json(json!({
+            "entry_ids": [42],
+            "status": "read"
+        })))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = provider_for(&server);
+    let item = Item {
+        id: ItemId::new("miniflux", "42"),
+        stream_id: StreamId::new("miniflux", "feed", "1"),
+        title: "x".to_string(),
+        content: ItemContent::Article {
+            summary: None,
+            full_content: None,
+        },
+        author: None,
+        published: None,
+        updated: None,
+        url: None,
+        thumbnail_url: None,
+        is_read: false,
+        is_saved: false,
+        tags: vec![],
+        metadata: Default::default(),
+    };
+    let action = Action {
+        id: "mark_read".to_string(),
+        name: "Mark as Read".to_string(),
+        description: String::new(),
+        kind: ActionKind::MarkRead,
+        keyboard_shortcut: None,
+    };
+    let result = provider.execute_action(&item, &action).await.unwrap();
+    assert!(result.success);
+}
+
+#[tokio::test]
+async fn star_action_round_trips_via_bookmark_endpoint() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/v1/entries/55/bookmark"))
+        .and(header("X-Auth-Token", "test-token"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = provider_for(&server);
+    let item = Item {
+        id: ItemId::new("miniflux", "55"),
+        stream_id: StreamId::new("miniflux", "feed", "1"),
+        title: "x".to_string(),
+        content: ItemContent::Article {
+            summary: None,
+            full_content: None,
+        },
+        author: None,
+        published: None,
+        updated: None,
+        url: None,
+        thumbnail_url: None,
+        is_read: false,
+        is_saved: false,
+        tags: vec![],
+        metadata: Default::default(),
+    };
+    let action = Action {
+        id: "save".to_string(),
+        name: "Star Article".to_string(),
+        description: String::new(),
+        kind: ActionKind::Save,
+        keyboard_shortcut: None,
+    };
+    let result = provider.execute_action(&item, &action).await.unwrap();
+    assert!(result.success);
+}
+
+#[tokio::test]
+async fn save_item_is_idempotent_when_already_starred() {
+    let server = MockServer::start().await;
+
+    // is_saved sees the entry already in the starred list, so toggle_bookmark
+    // must NOT be called.
+    Mock::given(method("GET"))
+        .and(path("/v1/entries"))
+        .and(query_param("starred", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "total": 1,
+            "entries": [{
+                "id": 77,
+                "user_id": 1,
+                "feed_id": 1,
+                "status": "read",
+                "hash": "h",
+                "title": "Already starred",
+                "url": "https://example.com/x",
+                "comments_url": "",
+                "published_at": null,
+                "created_at": null,
+                "changed_at": null,
+                "author": "",
+                "content": "",
+                "share_code": "",
+                "starred": true,
+                "reading_time": 0,
+                "enclosures": [],
+                "tags": [],
+                "feed": null
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = provider_for(&server);
+    provider
+        .save_item(&ItemId::new("miniflux", "77"))
+        .await
+        .unwrap();
+    // Successful return + the lone GET expectation is enough — wiremock would
+    // otherwise complain about an unexpected PUT on drop.
+}
+
+#[tokio::test]
+async fn unsave_item_toggles_when_currently_starred() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/entries"))
+        .and(query_param("starred", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "total": 1,
+            "entries": [{
+                "id": 88,
+                "user_id": 1,
+                "feed_id": 1,
+                "status": "read",
+                "hash": "h",
+                "title": "Will be unsaved",
+                "url": "https://example.com/x",
+                "comments_url": "",
+                "published_at": null,
+                "created_at": null,
+                "changed_at": null,
+                "author": "",
+                "content": "",
+                "share_code": "",
+                "starred": true,
+                "reading_time": 0,
+                "enclosures": [],
+                "tags": [],
+                "feed": null
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("PUT"))
+        .and(path("/v1/entries/88/bookmark"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = provider_for(&server);
+    provider
+        .unsave_item(&ItemId::new("miniflux", "88"))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn unauthorized_response_maps_to_auth_required() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/feeds"))
+        .respond_with(ResponseTemplate::new(401))
+        .mount(&server)
+        .await;
+
+    let provider = provider_for(&server);
+    let err = provider.list_feeds().await.unwrap_err();
+    assert!(
+        matches!(err, StreamError::AuthRequired(_)),
+        "expected AuthRequired, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn health_check_uses_me_endpoint() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/me"))
+        .and(header("X-Auth-Token", "test-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 1,
+            "username": "alice",
+            "is_admin": false
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = provider_for(&server);
+    let health = provider.health_check().await.unwrap();
+    assert!(health.is_healthy);
+    assert!(health.message.unwrap().contains("alice"));
+}


### PR DESCRIPTION
Closes #61.

## Summary

Adds `providers/provider-miniflux/`, a new provider crate that talks to a [Miniflux](https://miniflux.app) server's JSON API and implements `Provider + HasFeeds + HasSavedItems`. This is the always-on, multi-device counterpart to `provider-rss`: Miniflux owns "fetch and cache feeds," and Scryforge becomes a terminal-native client over the user's existing subscriptions. Aligns with the ecosystem split described in [`gudpkm/docs/15-feed-reader-integration.md`](https://github.com/beengud/gudpkm/blob/main/docs/15-feed-reader-integration.md).

## What's in the crate

- `api.rs` — typed Miniflux client over `reqwest` (`rustls-tls`). Covers `GET /v1/me`, `GET /v1/feeds`, `GET /v1/categories`, `GET /v1/entries` (with `status` / `feed_id` / `starred` / paging filters), `PUT /v1/entries` (bulk read/unread), and `PUT /v1/entries/<id>/bookmark` (toggle star). Auth via `X-Auth-Token` header. `MinifluxApiError` maps HTTP statuses into `StreamError` (401/403 → `AuthRequired`, 429 → `RateLimited`, etc.).
- `config.rs` — `MinifluxProviderConfig { server_url, api_token }`, with an optional `from_sigilforge` constructor behind the `sigilforge` cargo feature.
- `mapping.rs` — Miniflux `Entry` → Scryforge `Item` per the issue's mapping table.
- `lib.rs` — `MinifluxProvider` implementing the three traits. Read/unread and star/unstar actions round-trip to the server; `save_item` / `unsave_item` are idempotent (check current state before toggling, since the Miniflux endpoint is a toggle).
- `tests/integration_test.rs` — wiremock-driven integration tests (10 cases).
- `README.md` — usage, capability matrix, item mapping, errors, dependencies.

Workspace `Cargo.toml` gains the new member entry. No changes to `scryforge-provider-core` traits or other providers.

## Test plan

Local checks all pass against this branch:

```
cargo fmt --check -p provider-miniflux                                      # clean
CARGO_TARGET_DIR=./target cargo clippy -p provider-miniflux --all-targets -- -D warnings   # clean
CARGO_TARGET_DIR=./target cargo clippy -p provider-miniflux --all-targets --features sigilforge -- -D warnings  # clean
CARGO_TARGET_DIR=./target cargo test  -p provider-miniflux                  # 8 unit + 10 integration + 2 doctest = 20 passed
CARGO_TARGET_DIR=./target cargo test  -p provider-miniflux --features sigilforge   # same 20 passed
CARGO_TARGET_DIR=./target cargo doc   -p provider-miniflux --no-deps --all-features  # RUSTDOCFLAGS=-D warnings, clean
CARGO_TARGET_DIR=./target cargo clippy --workspace --exclude scarab-scryforge -- -D warnings   # clean
```

Wiremock test coverage:

- [x] List feeds (`GET /v1/feeds`)
- [x] List unread entries scoped to a feed (`GET /v1/entries?feed_id=...&status=unread`)
- [x] List starred entries via `HasSavedItems` (`GET /v1/entries?starred=true`)
- [x] `save_item` is idempotent when the entry is already starred
- [x] `unsave_item` toggles only when currently starred
- [x] Mark-read action round-trips via `PUT /v1/entries`
- [x] Star action round-trips via `PUT /v1/entries/<id>/bookmark`
- [x] 401 surfaces as `StreamError::AuthRequired`
- [x] `health_check` uses `GET /v1/me`
- [x] Unknown `FeedId` shape → `StreamError::StreamNotFound`

## Pre-existing CI issues (not introduced by this PR)

The CI workflow has been red on `main` for a while because the `scarab-scryforge` workspace member depends on a path-relative crate at `../../scarab/crates/scarab-plugin-api` that doesn't exist in a fresh CI checkout (and `cargo fmt --all` recurses into local path-deps, so it picks up unrelated formatting noise from that out-of-tree path on a developer machine that does have `scarab` checked out). Those failures are unrelated to this PR; flagging per workflow guidelines, not fixing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)