### PR TITLE
feat(provider-rss + actions): transcribe-to-vault for podcasts via Scribe

### DIFF
--- a/providers/provider-rss/Cargo.toml
+++ b/providers/provider-rss/Cargo.toml
@@ -28,5 +28,9 @@ opml = "1.1"
 # Error handling
 thiserror.workspace = true
 
+# Home/config directory resolution for transcribe output
+directories = "5.0"
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tempfile = "3.10"

--- a/providers/provider-rss/src/lib.rs
+++ b/providers/provider-rss/src/lib.rs
@@ -47,8 +47,24 @@ use scryforge_provider_core::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::any::Any;
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 use thiserror::Error;
+
+// ============================================================================
+// Public constants
+// ============================================================================
+
+/// Metadata key under which the audio enclosure URL (if any) is exposed on
+/// `Item.metadata`. Set when an RSS/Atom entry carries an audio enclosure or
+/// `<media:content>` element with an audio MIME type or audio file extension.
+pub const AUDIO_URL_METADATA_KEY: &str = "audio_url";
+
+/// Stable action ID for the transcribe-to-vault custom action.
+pub const TRANSCRIBE_ACTION_ID: &str = "transcribe_to_vault";
+
+/// File extensions treated as audio when MIME info is missing or unhelpful.
+const AUDIO_EXTENSIONS: &[&str] = &["mp3", "m4a", "ogg", "wav", "flac", "aac", "opus"];
 
 // ============================================================================
 // Error Types
@@ -93,12 +109,41 @@ impl From<RssError> for StreamError {
 pub struct RssProviderConfig {
     /// List of feed URLs to fetch
     pub feeds: Vec<String>,
+
+    /// Output directory for the `transcribe-to-vault` action. When `None`,
+    /// the provider falls back to `~/transcripts/scryforge` (resolved at
+    /// action-execution time via the `directories` crate).
+    #[serde(default)]
+    pub transcribe_dir: Option<PathBuf>,
+
+    /// Optional override for the `scribe` binary path. When `None`, the
+    /// `transcribe-to-vault` action invokes `scribe` from `$PATH`. Primarily
+    /// a hook for tests; production deployments should rely on `$PATH`.
+    #[serde(default)]
+    pub scribe_bin: Option<PathBuf>,
 }
 
 impl RssProviderConfig {
     /// Create a new configuration with the given feed URLs.
     pub fn new(feeds: Vec<String>) -> Self {
-        Self { feeds }
+        Self {
+            feeds,
+            transcribe_dir: None,
+            scribe_bin: None,
+        }
+    }
+
+    /// Builder-style: set the transcribe output directory.
+    pub fn with_transcribe_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.transcribe_dir = Some(dir.into());
+        self
+    }
+
+    /// Builder-style: set an explicit path to the `scribe` binary
+    /// (otherwise resolved from `$PATH`).
+    pub fn with_scribe_bin(mut self, bin: impl Into<PathBuf>) -> Self {
+        self.scribe_bin = Some(bin.into());
+        self
     }
 
     /// Create a configuration from an OPML file.
@@ -116,7 +161,11 @@ impl RssProviderConfig {
         let mut feeds = Vec::new();
         Self::extract_feeds_from_outline(&document.body.outlines, &mut feeds);
 
-        Ok(Self { feeds })
+        Ok(Self {
+            feeds,
+            transcribe_dir: None,
+            scribe_bin: None,
+        })
     }
 
     /// Recursively extract feed URLs from OPML outlines.
@@ -133,6 +182,123 @@ impl RssProviderConfig {
             }
         }
     }
+}
+
+// ============================================================================
+// Audio enclosure detection
+// ============================================================================
+
+/// Return `true` if the given MIME type looks like an audio MIME (i.e.
+/// starts with `audio/` ASCII-case-insensitively).
+fn is_audio_mime(mime: &str) -> bool {
+    mime.trim().to_ascii_lowercase().starts_with("audio/")
+}
+
+/// Return `true` if the URL's path component ends in a known audio
+/// extension. Handles query strings and fragments.
+fn url_has_audio_extension(url: &str) -> bool {
+    // Strip query string and fragment so a URL like
+    // `https://example.com/ep1.mp3?token=abc#t=10` still matches.
+    let path = url
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(url)
+        .to_ascii_lowercase();
+
+    AUDIO_EXTENSIONS
+        .iter()
+        .any(|ext| path.ends_with(&format!(".{ext}")))
+}
+
+/// Walk the entry's `<media:content>` children (which feed-rs uses to surface
+/// both Media RSS `<media:content>` and standard RSS `<enclosure>`) and
+/// return the first URL that looks audio-y. The check is:
+///
+/// 1. MIME type starts with `audio/`, OR
+/// 2. URL has a known audio extension (`.mp3`, `.m4a`, `.ogg`, ...).
+fn extract_audio_url(entry: &feed_rs::model::Entry) -> Option<String> {
+    for media in &entry.media {
+        for content in &media.content {
+            // Prefer the explicit MIME type.
+            if let Some(mime) = &content.content_type {
+                if is_audio_mime(mime.as_ref()) {
+                    if let Some(url) = &content.url {
+                        return Some(url.to_string());
+                    }
+                }
+            }
+            // Fall back to extension sniffing.
+            if let Some(url) = &content.url {
+                if url_has_audio_extension(url.as_ref()) {
+                    return Some(url.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Resolve the transcribe output directory: prefer the per-stream config,
+/// else `~/transcripts/scryforge`, else the current working directory as a
+/// last resort. Creates the directory if it does not exist.
+fn resolve_transcribe_dir(configured: Option<&Path>) -> std::result::Result<PathBuf, RssError> {
+    let dir = if let Some(p) = configured {
+        p.to_path_buf()
+    } else {
+        match directories::UserDirs::new() {
+            Some(user_dirs) => user_dirs.home_dir().join("transcripts").join("scryforge"),
+            None => PathBuf::from("."),
+        }
+    };
+
+    if !dir.exists() {
+        std::fs::create_dir_all(&dir).map_err(RssError::Io)?;
+    }
+    Ok(dir)
+}
+
+/// Parse scribe's stdout for the path of the produced markdown file. Scribe
+/// (per `docs/04-cli-reference.md`) writes a `<slug>-<timestamp>.md` and a
+/// matching `.json` to the configured output directory. The conventional way
+/// to surface that path is via stdout; if scribe ever changes its stdout
+/// format we fall back to a glob of `*.md` in the output directory.
+fn parse_scribe_output_path(stdout: &str, out_dir: &Path) -> Option<PathBuf> {
+    // Heuristic: scan stdout for tokens ending in `.md`. Choose the last one
+    // (scribe is expected to log the result file last).
+    let candidate = stdout
+        .split_whitespace()
+        .rev()
+        .find(|tok| tok.ends_with(".md"))
+        .map(|s| {
+            s.trim_matches(|c: char| !c.is_ascii_graphic() || c == '"' || c == '\'')
+                .to_string()
+        });
+
+    if let Some(c) = candidate {
+        let p = PathBuf::from(&c);
+        if p.is_absolute() {
+            return Some(p);
+        }
+        return Some(out_dir.join(p));
+    }
+
+    // Fallback: pick the most recently modified .md in out_dir.
+    let mut newest: Option<(std::time::SystemTime, PathBuf)> = None;
+    if let Ok(entries) = std::fs::read_dir(out_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) == Some("md") {
+                if let Ok(meta) = entry.metadata() {
+                    if let Ok(modified) = meta.modified() {
+                        if newest.as_ref().is_none_or(|(t, _)| modified > *t) {
+                            newest = Some((modified, path));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    newest.map(|(_, p)| p)
 }
 
 // ============================================================================
@@ -248,6 +414,13 @@ impl RssProvider {
             }
         }
 
+        // Detect audio enclosure (podcast support). This walks every
+        // `<media:group>` / `<media:content>` on the entry and surfaces the
+        // first URL that looks audio-y via either MIME type or extension.
+        if let Some(audio_url) = extract_audio_url(entry) {
+            metadata.insert(AUDIO_URL_METADATA_KEY.to_string(), audio_url);
+        }
+
         Item {
             id: ItemId::new("rss", &entry_id),
             stream_id: stream_id.clone(),
@@ -263,6 +436,97 @@ impl RssProvider {
             tags,
             metadata,
         }
+    }
+
+    /// Run Scribe on the audio enclosure of `item` and return an
+    /// `ActionResult` describing the outcome.
+    ///
+    /// The body shells out to `scribe transcribe --input <url> --out-dir <dir>`
+    /// via `tokio::process::Command` so it does not block the daemon's
+    /// runtime; the future yields while whisper runs. The configured
+    /// `transcribe_dir` (or `~/transcripts/scryforge`) is created if missing.
+    /// On success, the path of the produced markdown is parsed from scribe's
+    /// stdout and returned in `ActionResult.data`.
+    async fn transcribe_item(&self, item: &Item) -> Result<ActionResult> {
+        let audio_url = match item.metadata.get(AUDIO_URL_METADATA_KEY) {
+            Some(u) => u.clone(),
+            None => {
+                return Ok(ActionResult {
+                    success: false,
+                    message: Some(
+                        "Item has no audio enclosure; transcribe-to-vault is only \
+                         valid on podcast items."
+                            .to_string(),
+                    ),
+                    data: None,
+                });
+            }
+        };
+
+        let out_dir = resolve_transcribe_dir(self.config.transcribe_dir.as_deref())
+            .map_err(StreamError::from)?;
+
+        let scribe_bin = self
+            .config
+            .scribe_bin
+            .as_deref()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| PathBuf::from("scribe"));
+
+        let mut cmd = tokio::process::Command::new(&scribe_bin);
+        cmd.arg("transcribe")
+            .arg("--input")
+            .arg(&audio_url)
+            .arg("--out-dir")
+            .arg(&out_dir)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+
+        let output = cmd
+            .spawn()
+            .map_err(|e| {
+                StreamError::Provider(format!(
+                    "Failed to spawn `{}`: {}. Is Scribe installed and on $PATH?",
+                    scribe_bin.display(),
+                    e
+                ))
+            })?
+            .wait_with_output()
+            .await
+            .map_err(|e| StreamError::Provider(format!("Scribe process error: {e}")))?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+        if !output.status.success() {
+            return Ok(ActionResult {
+                success: false,
+                message: Some(format!(
+                    "Scribe exited with status {}: {}",
+                    output.status,
+                    stderr.trim()
+                )),
+                data: Some(serde_json::json!({
+                    "exit_code": output.status.code(),
+                    "stderr": stderr,
+                })),
+            });
+        }
+
+        let md_path = parse_scribe_output_path(&stdout, &out_dir);
+
+        Ok(ActionResult {
+            success: true,
+            message: Some(match &md_path {
+                Some(p) => format!("Transcript written to {}", p.display()),
+                None => format!("Transcript written under {}", out_dir.display()),
+            }),
+            data: Some(serde_json::json!({
+                "out_dir": out_dir,
+                "output_path": md_path,
+                "audio_url": audio_url,
+            })),
+        })
     }
 }
 
@@ -340,8 +604,8 @@ impl Provider for RssProvider {
         }
     }
 
-    async fn available_actions(&self, _item: &Item) -> Result<Vec<Action>> {
-        Ok(vec![
+    async fn available_actions(&self, item: &Item) -> Result<Vec<Action>> {
+        let mut actions = vec![
             Action {
                 id: "open_browser".to_string(),
                 name: "Open in Browser".to_string(),
@@ -377,11 +641,28 @@ impl Provider for RssProvider {
                 kind: ActionKind::Save,
                 keyboard_shortcut: Some("s".to_string()),
             },
-        ])
+        ];
+
+        // Surface transcribe-to-vault only on items that look like podcast
+        // episodes (i.e. carry an audio enclosure URL in metadata).
+        if item.metadata.contains_key(AUDIO_URL_METADATA_KEY) {
+            actions.push(Action {
+                id: TRANSCRIBE_ACTION_ID.to_string(),
+                name: "Transcribe to Vault".to_string(),
+                description: "Run Scribe (whisper.cpp) on this episode's audio \
+                              and write a Markdown transcript to the configured \
+                              transcribe directory."
+                    .to_string(),
+                kind: ActionKind::Custom(TRANSCRIBE_ACTION_ID.to_string()),
+                keyboard_shortcut: Some("t".to_string()),
+            });
+        }
+
+        Ok(actions)
     }
 
     async fn execute_action(&self, item: &Item, action: &Action) -> Result<ActionResult> {
-        match action.kind {
+        match &action.kind {
             ActionKind::OpenInBrowser => {
                 if let Some(url) = &item.url {
                     Ok(ActionResult {
@@ -411,6 +692,9 @@ impl Provider for RssProvider {
                         data: None,
                     })
                 }
+            }
+            ActionKind::Custom(id) if id == TRANSCRIBE_ACTION_ID => {
+                self.transcribe_item(item).await
             }
             _ => Ok(ActionResult {
                 success: true,
@@ -796,5 +1080,399 @@ mod tests {
         let result = provider.execute_action(&item, &action).await.unwrap();
         assert!(!result.success);
         assert!(result.message.unwrap().contains("No URL available"));
+    }
+
+    // ====================================================================
+    // Audio enclosure detection (podcast support)
+    // ====================================================================
+
+    /// Synthetic podcast RSS with a typed audio enclosure (the canonical
+    /// podcast pattern: `<enclosure type="audio/mpeg" url="..."/>`).
+    const SAMPLE_PODCAST_RSS: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Podcast</title>
+    <link>https://example.com/podcast</link>
+    <description>A test podcast</description>
+    <item>
+      <title>Episode 42 — The Answer</title>
+      <link>https://example.com/podcast/ep42</link>
+      <description>Show notes for ep 42.</description>
+      <pubDate>Mon, 28 Apr 2026 14:30:00 GMT</pubDate>
+      <enclosure url="https://cdn.example.com/podcast/ep42.mp3" length="123456789" type="audio/mpeg"/>
+    </item>
+    <item>
+      <title>Episode 43 — Untyped enclosure</title>
+      <link>https://example.com/podcast/ep43</link>
+      <description>This one omits the type attribute; we should still detect via .mp3 ext.</description>
+      <pubDate>Tue, 29 Apr 2026 14:30:00 GMT</pubDate>
+      <enclosure url="https://cdn.example.com/podcast/ep43.mp3?token=abc" length="98765" type=""/>
+    </item>
+    <item>
+      <title>Article with no audio</title>
+      <link>https://example.com/podcast/post1</link>
+      <description>Just text.</description>
+      <pubDate>Wed, 30 Apr 2026 14:30:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>"#;
+
+    #[test]
+    fn test_is_audio_mime() {
+        assert!(is_audio_mime("audio/mpeg"));
+        assert!(is_audio_mime("AUDIO/MP4"));
+        assert!(is_audio_mime("  audio/ogg  "));
+        assert!(!is_audio_mime("video/mp4"));
+        assert!(!is_audio_mime("text/html"));
+        assert!(!is_audio_mime(""));
+    }
+
+    #[test]
+    fn test_url_has_audio_extension() {
+        assert!(url_has_audio_extension("https://example.com/ep1.mp3"));
+        assert!(url_has_audio_extension("https://example.com/ep1.MP3"));
+        assert!(url_has_audio_extension("https://example.com/ep1.m4a"));
+        assert!(url_has_audio_extension("https://example.com/ep1.ogg"));
+        assert!(url_has_audio_extension("https://example.com/ep1.wav"));
+        assert!(url_has_audio_extension("https://example.com/ep1.flac"));
+        assert!(url_has_audio_extension(
+            "https://example.com/ep1.mp3?token=abc"
+        ));
+        assert!(url_has_audio_extension("https://example.com/ep1.mp3#t=10"));
+        assert!(!url_has_audio_extension("https://example.com/ep1.mp4"));
+        assert!(!url_has_audio_extension("https://example.com/index.html"));
+        assert!(!url_has_audio_extension("https://example.com/"));
+    }
+
+    #[test]
+    fn test_extract_audio_url_from_typed_enclosure() {
+        let feed = parser::parse(SAMPLE_PODCAST_RSS.as_bytes()).unwrap();
+        // First item: typed audio/mpeg enclosure.
+        let url = extract_audio_url(&feed.entries[0]);
+        assert_eq!(
+            url.as_deref(),
+            Some("https://cdn.example.com/podcast/ep42.mp3")
+        );
+    }
+
+    #[test]
+    fn test_extract_audio_url_from_extension_fallback() {
+        let feed = parser::parse(SAMPLE_PODCAST_RSS.as_bytes()).unwrap();
+        // Second item: empty/missing type but .mp3 extension.
+        let url = extract_audio_url(&feed.entries[1]);
+        assert!(url.is_some(), "expected audio url via extension fallback");
+        let url = url.unwrap();
+        assert!(url.starts_with("https://cdn.example.com/podcast/ep43.mp3"));
+    }
+
+    #[test]
+    fn test_extract_audio_url_none_for_text_item() {
+        let feed = parser::parse(SAMPLE_PODCAST_RSS.as_bytes()).unwrap();
+        // Third item: no enclosure at all.
+        let url = extract_audio_url(&feed.entries[2]);
+        assert!(url.is_none());
+    }
+
+    #[test]
+    fn test_entry_to_item_populates_audio_url_metadata() {
+        let feed = parser::parse(SAMPLE_PODCAST_RSS.as_bytes()).unwrap();
+        let provider = RssProvider::new(RssProviderConfig::new(vec![
+            "https://example.com".to_string()
+        ]));
+        let stream_id = StreamId::new("rss", "feed", "rss:0");
+
+        let podcast_item =
+            provider.entry_to_item(&feed.entries[0], &stream_id, "https://example.com");
+        assert_eq!(
+            podcast_item
+                .metadata
+                .get(AUDIO_URL_METADATA_KEY)
+                .map(String::as_str),
+            Some("https://cdn.example.com/podcast/ep42.mp3"),
+        );
+
+        let text_item = provider.entry_to_item(&feed.entries[2], &stream_id, "https://example.com");
+        assert!(!text_item.metadata.contains_key(AUDIO_URL_METADATA_KEY));
+    }
+
+    // ====================================================================
+    // transcribe-to-vault action
+    // ====================================================================
+
+    fn make_podcast_item(audio_url: &str) -> Item {
+        let mut metadata = HashMap::new();
+        metadata.insert(AUDIO_URL_METADATA_KEY.to_string(), audio_url.to_string());
+        Item {
+            id: ItemId::new("rss", "ep42"),
+            stream_id: StreamId::new("rss", "feed", "rss:0"),
+            title: "Episode 42".to_string(),
+            content: ItemContent::Article {
+                summary: None,
+                full_content: None,
+            },
+            author: None,
+            published: None,
+            updated: None,
+            url: Some("https://example.com/podcast/ep42".to_string()),
+            thumbnail_url: None,
+            is_read: false,
+            is_saved: false,
+            tags: vec![],
+            metadata,
+        }
+    }
+
+    fn make_article_item() -> Item {
+        Item {
+            id: ItemId::new("rss", "post1"),
+            stream_id: StreamId::new("rss", "feed", "rss:0"),
+            title: "Article".to_string(),
+            content: ItemContent::Article {
+                summary: None,
+                full_content: None,
+            },
+            author: None,
+            published: None,
+            updated: None,
+            url: Some("https://example.com/post1".to_string()),
+            thumbnail_url: None,
+            is_read: false,
+            is_saved: false,
+            tags: vec![],
+            metadata: Default::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_available_actions_includes_transcribe_for_podcast() {
+        let provider = RssProvider::new(RssProviderConfig::new(vec![]));
+        let podcast = make_podcast_item("https://cdn.example.com/ep1.mp3");
+
+        let actions = provider.available_actions(&podcast).await.unwrap();
+        let has_transcribe = actions.iter().any(|a| {
+            a.id == TRANSCRIBE_ACTION_ID
+                && matches!(&a.kind, ActionKind::Custom(s) if s == TRANSCRIBE_ACTION_ID)
+        });
+        assert!(
+            has_transcribe,
+            "expected transcribe-to-vault action on items with audio_url metadata"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_available_actions_omits_transcribe_for_article() {
+        let provider = RssProvider::new(RssProviderConfig::new(vec![]));
+        let article = make_article_item();
+
+        let actions = provider.available_actions(&article).await.unwrap();
+        let has_transcribe = actions.iter().any(|a| a.id == TRANSCRIBE_ACTION_ID);
+        assert!(
+            !has_transcribe,
+            "transcribe-to-vault should be hidden on items without audio enclosure"
+        );
+    }
+
+    /// Build a fake `scribe` shell script that:
+    ///   - parses `--input` and `--out-dir`
+    ///   - writes a `<stem>-mock.md` and matching `.json` to the out-dir
+    ///   - prints the markdown path to stdout
+    ///   - exits 0
+    ///
+    /// On non-Unix, this test is skipped.
+    #[cfg(unix)]
+    fn make_fake_scribe(dir: &Path) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let path = dir.join("scribe");
+        let script = r#"#!/usr/bin/env bash
+set -euo pipefail
+input=""
+outdir=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    transcribe) shift ;;
+    --input) input="$2"; shift 2 ;;
+    --out-dir) outdir="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+mkdir -p "$outdir"
+stem=$(basename "$input" | sed 's/\.[^.]*$//' | tr -c 'a-zA-Z0-9' '-' | sed 's/-\+/-/g; s/^-//; s/-$//')
+md="$outdir/${stem}-mock.md"
+json="$outdir/${stem}-mock.json"
+echo "---" > "$md"
+echo "type: transcript" >> "$md"
+echo "---" >> "$md"
+echo "fake transcript body" >> "$md"
+echo "{}" > "$json"
+echo "$md"
+"#;
+        std::fs::write(&path, script).unwrap();
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).unwrap();
+        path
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_transcribe_action_invokes_scribe() {
+        let tmp = tempfile::tempdir().unwrap();
+        let scribe_bin = make_fake_scribe(tmp.path());
+        let out_dir = tmp.path().join("transcripts");
+
+        let config = RssProviderConfig::new(vec![])
+            .with_transcribe_dir(&out_dir)
+            .with_scribe_bin(&scribe_bin);
+        let provider = RssProvider::new(config);
+
+        let item = make_podcast_item("https://cdn.example.com/podcast/ep42.mp3");
+        let action = Action {
+            id: TRANSCRIBE_ACTION_ID.to_string(),
+            name: "Transcribe to Vault".to_string(),
+            description: String::new(),
+            kind: ActionKind::Custom(TRANSCRIBE_ACTION_ID.to_string()),
+            keyboard_shortcut: None,
+        };
+
+        let result = provider.execute_action(&item, &action).await.unwrap();
+        assert!(
+            result.success,
+            "expected success, got: {:?}",
+            result.message
+        );
+        let data = result.data.expect("expected data payload");
+        let output_path = data
+            .get("output_path")
+            .and_then(|v| v.as_str())
+            .expect("output_path should be present");
+        assert!(
+            output_path.ends_with(".md"),
+            "expected markdown path, got {output_path}"
+        );
+        assert!(
+            std::path::Path::new(output_path).exists(),
+            "fake scribe should have written {output_path}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_transcribe_action_propagates_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Fake "scribe" that always fails.
+        let scribe_bin = tmp.path().join("scribe");
+        std::fs::write(
+            &scribe_bin,
+            "#!/usr/bin/env bash\necho 'boom' 1>&2\nexit 7\n",
+        )
+        .unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&scribe_bin).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&scribe_bin, perms).unwrap();
+
+        let out_dir = tmp.path().join("transcripts");
+        let config = RssProviderConfig::new(vec![])
+            .with_transcribe_dir(&out_dir)
+            .with_scribe_bin(&scribe_bin);
+        let provider = RssProvider::new(config);
+
+        let item = make_podcast_item("https://cdn.example.com/ep1.mp3");
+        let action = Action {
+            id: TRANSCRIBE_ACTION_ID.to_string(),
+            name: "Transcribe to Vault".to_string(),
+            description: String::new(),
+            kind: ActionKind::Custom(TRANSCRIBE_ACTION_ID.to_string()),
+            keyboard_shortcut: None,
+        };
+
+        let result = provider.execute_action(&item, &action).await.unwrap();
+        assert!(
+            !result.success,
+            "expected failure when scribe exits non-zero"
+        );
+        assert!(result.message.unwrap().contains("boom"));
+    }
+
+    #[tokio::test]
+    async fn test_transcribe_action_without_audio_url_returns_clear_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let provider =
+            RssProvider::new(RssProviderConfig::new(vec![]).with_transcribe_dir(tmp.path()));
+
+        let item = make_article_item(); // no audio_url metadata
+        let action = Action {
+            id: TRANSCRIBE_ACTION_ID.to_string(),
+            name: "Transcribe to Vault".to_string(),
+            description: String::new(),
+            kind: ActionKind::Custom(TRANSCRIBE_ACTION_ID.to_string()),
+            keyboard_shortcut: None,
+        };
+
+        let result = provider.execute_action(&item, &action).await.unwrap();
+        assert!(!result.success);
+        assert!(result.message.unwrap().contains("audio enclosure"));
+    }
+
+    /// Real-scribe smoke test. Skipped by default; opt in with
+    /// `cargo test -p provider-rss --ignored`.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[ignore]
+    async fn test_transcribe_action_real_scribe_smoke() {
+        // Requires `scribe` on $PATH AND a small audio fixture at
+        // $SCRYFORGE_TEST_AUDIO. Otherwise it's a no-op pass.
+        let audio = match std::env::var("SCRYFORGE_TEST_AUDIO") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SCRYFORGE_TEST_AUDIO not set; skipping real-scribe smoke");
+                return;
+            }
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let provider =
+            RssProvider::new(RssProviderConfig::new(vec![]).with_transcribe_dir(tmp.path()));
+        let item = make_podcast_item(&audio);
+        let action = Action {
+            id: TRANSCRIBE_ACTION_ID.to_string(),
+            name: "Transcribe to Vault".to_string(),
+            description: String::new(),
+            kind: ActionKind::Custom(TRANSCRIBE_ACTION_ID.to_string()),
+            keyboard_shortcut: None,
+        };
+        let result = provider.execute_action(&item, &action).await.unwrap();
+        assert!(result.success, "real scribe failed: {:?}", result.message);
+    }
+
+    // ====================================================================
+    // parse_scribe_output_path
+    // ====================================================================
+
+    #[test]
+    fn test_parse_scribe_output_path_from_stdout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stdout = "/abs/path/to/episode-42-20260428-143000.md\n";
+        let p = parse_scribe_output_path(stdout, tmp.path());
+        assert_eq!(
+            p.as_deref(),
+            Some(Path::new("/abs/path/to/episode-42-20260428-143000.md"))
+        );
+    }
+
+    #[test]
+    fn test_parse_scribe_output_path_relative_resolves_against_outdir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stdout = "ep1.md\n";
+        let p = parse_scribe_output_path(stdout, tmp.path());
+        assert_eq!(p, Some(tmp.path().join("ep1.md")));
+    }
+
+    #[test]
+    fn test_parse_scribe_output_path_falls_back_to_dir_scan() {
+        let tmp = tempfile::tempdir().unwrap();
+        let md = tmp.path().join("only-one.md");
+        std::fs::write(&md, "x").unwrap();
+        let p = parse_scribe_output_path("done\n", tmp.path());
+        assert_eq!(p, Some(md));
     }
 }


### PR DESCRIPTION
## Summary

- Adds audio enclosure detection to `provider-rss`: when a feed entry carries a `<media:content>` / `<enclosure>` with `audio/*` MIME (or a `.mp3 / .m4a / .ogg / .wav / .flac / .aac / .opus` URL), the URL is exposed on `Item.metadata["audio_url"]` (key constant: `provider_rss::AUDIO_URL_METADATA_KEY`).
- Adds a `transcribe-to-vault` custom action (`ActionKind::Custom("transcribe_to_vault")`, id constant: `provider_rss::TRANSCRIBE_ACTION_ID`) that shells out to `scribe transcribe --input <url> --out-dir <dir>` via `tokio::process::Command` and returns the output markdown path. Surfaced from `available_actions` only on items with `audio_url` metadata.
- New per-stream config: `RssProviderConfig.transcribe_dir: Option<PathBuf>` (defaults to `~/transcripts/scryforge`). Plus `scribe_bin: Option<PathBuf>` as a test-only hook; production deployments rely on `$PATH`.

## Design notes

- **Scribe is the engine, scryforge is the workflow surface** — see [scribe/docs/03-related-tools.md](https://github.com/raibid-labs/scribe/blob/main/docs/03-related-tools.md). No `libwhisper` / `libavformat` linkage in scryforge.
- **Async strategy.** `execute_action` is already `async`; it spawns scribe with `tokio::process::Command` and awaits `wait_with_output()`. The daemon caller is free to run the action on its own tokio task to keep the main loop responsive while whisper grinds (minutes for hour-long episodes).
- **No core-trait change.** `Action` is still `ActionKind::Custom`; `Item.metadata: HashMap<String, String>` carries the audio URL. This avoids reshaping `scryforge-provider-core` for one provider.
- **Output path discovery.** Scribe (per its docs) writes `<slug>-<timestamp>.md`. We parse the path from scribe's stdout (last `.md` token), falling back to a directory scan for the most recently modified `.md`.

## Tests

- Unit: MIME detection (`audio/mpeg`, case/whitespace handling), URL extension fallback (with query strings and fragments), audio URL extraction from typed and untyped enclosures, `Item.metadata` population, podcast-vs-article action surfacing.
- Integration: end-to-end action execution against a synthesized `scribe` shell script (Unix-only; `cfg(unix)`-gated). Both success and non-zero-exit paths.
- Opt-in real-scribe smoke: `#[ignore]`'d `test_transcribe_action_real_scribe_smoke` runs against `scribe` on `$PATH` plus `SCRYFORGE_TEST_AUDIO`.

All 24 lib tests pass. `cargo clippy -p provider-rss --all-targets --all-features -- -D warnings` clean. Workspace-wide clippy has a pre-existing FFI-safety warning in `scarab-scryforge` unrelated to this PR.

## Test plan

- [x] `cargo test -p provider-rss` (24 pass, 1 ignored)
- [x] `cargo test --workspace --lib` (all green)
- [x] `cargo clippy -p provider-rss --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -p provider-rss -- --check`
- [ ] Reviewer: opt-in real-scribe smoke with `SCRYFORGE_TEST_AUDIO=/path/to/short.mp3 cargo test -p provider-rss --ignored`

## Out of scope

- `provider-youtube` + `yt-dlp` integration (separate follow-up).
- Per-item action approval gates / TUI confirmation prompts.
- Transcript post-processing (Scribe is verbatim only by design).

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)